### PR TITLE
Add group endpoint API tests

### DIFF
--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -17,6 +17,12 @@
 ./run_tests [999] -ss -sc
 ```
 
+Maybe:
+```bash
+#./run_tests <object>(<endpoint>[<selection>, ...], ...), ...
+./run_tests user(add[1-5,10],delete) group delete[1,2,5-10]
+```
+
 ## To Develop
 
 Add test files with a name of the form: `test_<object><priority>_<endpoint>[_<detail>].py`.

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -7,6 +7,8 @@
 ./run_tests
 # run a subset of the tests
 ./run_tests [1-5,10]
+# run all user tests
+./run_tests user
 # run all the user add tests
 ./run_tests user_add
 # run specific tests in user add
@@ -15,12 +17,6 @@
 ./run_tests user_list user_add[1-5,10] user_delete
 # skip setup, cleanup, and all tests
 ./run_tests [999] -ss -sc
-```
-
-Maybe:
-```bash
-#./run_tests <object>(<endpoint>[<selection>, ...], ...), ...
-./run_tests user(add[1-5,10],delete) group delete[1,2,5-10]
 ```
 
 ## To Develop

--- a/unit_tests/group_requests_cleanup.py
+++ b/unit_tests/group_requests_cleanup.py
@@ -31,6 +31,11 @@ def main(gvar):
 
     execute_csv2_request(
         gvar, None, None, None,
+        '/user/delete/', form_data={'username': ut_id(gvar, 'gtu5')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
         '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg1')}
     )
 
@@ -52,6 +57,11 @@ def main(gvar):
     execute_csv2_request(
         gvar, None, None, None,
         '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg5')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg6')}
     )
 
 if __name__ == "__main__":

--- a/unit_tests/group_requests_cleanup.py
+++ b/unit_tests/group_requests_cleanup.py
@@ -1,0 +1,58 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/user/delete/', form_data={'username': ut_id(gvar, 'gtu1')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/user/delete/', form_data={'username': ut_id(gvar, 'gtu2')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/user/delete/', form_data={'username': ut_id(gvar, 'gtu3')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/user/delete/', form_data={'username': ut_id(gvar, 'gtu4')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg1')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg2')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg3')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg4')}
+    )
+
+    execute_csv2_request(
+        gvar, None, None, None,
+        '/group/delete/', form_data={'group_name': ut_id(gvar, 'gtg5')}
+    )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/group_requests_setup.py
+++ b/unit_tests/group_requests_setup.py
@@ -1,0 +1,101 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+import group_requests_cleanup
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    group_requests_cleanup.main(gvar)
+
+    # unprivileged user in no groups
+    execute_csv2_request(
+        gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu1')),
+            '/user/add/', form_data={
+                'username': ut_id(gvar, 'gtu1'),
+                'password1': 'Abc123',
+                'password2': 'Abc123',
+                'cert_cn': '{} test user one'.format(ut_id(gvar, 'group'))
+            }
+        )
+    
+    # privileged user in no groups
+    execute_csv2_request(
+        gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu2')),
+            '/user/add/', form_data={
+                'username': ut_id(gvar, 'gtu2'),
+                'password1': 'Abc123',
+                'password2': 'Abc123',
+                'cert_cn': '{} test user two'.format(ut_id(gvar, 'group')),
+                'is_superuser': 1
+            }
+        )
+    
+    # group to be changed in group_update
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully added.'.format(ut_id(gvar, 'gtg4')),
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'condor_central_manager': 'unit-test-group-four.ca'
+        }
+    )
+
+    # group to be changed in group_yaml_*
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully added.'.format(ut_id(gvar, 'gtg5')),
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg5'),
+            'condor_central_manager': 'unit-test-group-five.ca'
+        }
+    )
+
+    # unprivileged user in group gtg4
+    execute_csv2_request(
+        gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu3')),
+            '/user/add/', form_data={
+                'username': ut_id(gvar, 'gtu3'),
+                'password1': 'Abc123',
+                'password2': 'Abc123',
+                'cert_cn': '{} test user three'.format(ut_id(gvar, 'group')),
+                'group_name.1': ut_id(gvar, 'gtg4'),
+                'group_name.2': ut_id(gvar, 'gtg5')
+            }
+        )
+    
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty4')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg5'),
+            'metadata_name': ut_id(gvar, 'gty4'),
+            'metadata': '- example: yaml'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg5'),
+            'metadata_name': ut_id(gvar, 'gty5'),
+            'metadata': '- example: yaml'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+    
+    # unprivileged user to be added to groups
+    execute_csv2_request(
+        gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu4')),
+            '/user/add/', form_data={
+                'username': ut_id(gvar, 'gtu4'),
+                'password1': 'Abc123',
+                'password2': 'Abc123',
+                'cert_cn': '{} test user four'.format(ut_id(gvar, 'group'))
+            }
+        )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/group_requests_setup.py
+++ b/unit_tests/group_requests_setup.py
@@ -70,7 +70,8 @@ def main(gvar):
             'password1': 'Abc123',
             'password2': 'Abc123',
             'cert_cn': '{} test user three'.format(ut_id(gvar, 'group')),
-            'group_name.1': ut_id(gvar, 'gtg5')
+            'group_name.1': ut_id(gvar, 'gtg4'),
+            'group_name.2': ut_id(gvar, 'gtg5')
         }
     )
 
@@ -83,8 +84,9 @@ def main(gvar):
             'password2': 'Abc123',
             'is_superuser': 1,
             'cert_cn': '{} test user five'.format(ut_id(gvar, 'group')),
-            'group_name.1': ut_id(gvar, 'gtg5'),
-            'group_name.2': ut_id(gvar, 'gtg6')
+            'group_name.1': ut_id(gvar, 'gtg4'),
+            'group_name.2': ut_id(gvar, 'gtg5'),
+            'group_name.3': ut_id(gvar, 'gtg6')
         }
     )
     

--- a/unit_tests/group_requests_setup.py
+++ b/unit_tests/group_requests_setup.py
@@ -49,22 +49,46 @@ def main(gvar):
         gvar, 0, None, 'group "{}" successfully added.'.format(ut_id(gvar, 'gtg5')),
         '/group/add/', form_data={
             'group_name': ut_id(gvar, 'gtg5'),
-            'condor_central_manager': 'unit-test-group-five.ca'
+            'condor_central_manager': 'unit-test-group-five.ca',
+        }
+    )
+
+    # group to be deleted in group_delete
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully added.'.format(ut_id(gvar, 'gtg6')),
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg6'),
+            'condor_central_manager': 'unit-test-group-six.ca',
         }
     )
 
     # unprivileged user in group gtg4
     execute_csv2_request(
         gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu3')),
-            '/user/add/', form_data={
-                'username': ut_id(gvar, 'gtu3'),
-                'password1': 'Abc123',
-                'password2': 'Abc123',
-                'cert_cn': '{} test user three'.format(ut_id(gvar, 'group')),
-                'group_name.1': ut_id(gvar, 'gtg4'),
-                'group_name.2': ut_id(gvar, 'gtg5')
-            }
-        )
+        '/user/add/', form_data={
+            'username': ut_id(gvar, 'gtu3'),
+            'password1': 'Abc123',
+            'password2': 'Abc123',
+            'cert_cn': '{} test user three'.format(ut_id(gvar, 'group')),
+            'group_name.1': ut_id(gvar, 'gtg4'),
+            'group_name.2': ut_id(gvar, 'gtg5')
+        }
+    )
+
+    # privileged user in group gtg4,5,6
+    execute_csv2_request(
+        gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu5')),
+        '/user/add/', form_data={
+            'username': ut_id(gvar, 'gtu5'),
+            'password1': 'Abc123',
+            'password2': 'Abc123',
+            'is_superuser': 1,
+            'cert_cn': '{} test user five'.format(ut_id(gvar, 'group')),
+            'group_name.1': ut_id(gvar, 'gtg4'),
+            'group_name.2': ut_id(gvar, 'gtg5'),
+            'group_name.2': ut_id(gvar, 'gtg6')
+        }
+    )
     
     execute_csv2_request(
         gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty4')),

--- a/unit_tests/group_requests_setup.py
+++ b/unit_tests/group_requests_setup.py
@@ -62,7 +62,7 @@ def main(gvar):
         }
     )
 
-    # unprivileged user in group gtg4
+    # unprivileged user in group gtg5
     execute_csv2_request(
         gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu3')),
         '/user/add/', form_data={
@@ -70,12 +70,11 @@ def main(gvar):
             'password1': 'Abc123',
             'password2': 'Abc123',
             'cert_cn': '{} test user three'.format(ut_id(gvar, 'group')),
-            'group_name.1': ut_id(gvar, 'gtg4'),
-            'group_name.2': ut_id(gvar, 'gtg5')
+            'group_name.1': ut_id(gvar, 'gtg5')
         }
     )
 
-    # privileged user in group gtg4,5,6
+    # privileged user in group gtg5,6
     execute_csv2_request(
         gvar, 0, None, 'user "{}" successfully added.'.format(ut_id(gvar, 'gtu5')),
         '/user/add/', form_data={
@@ -84,8 +83,7 @@ def main(gvar):
             'password2': 'Abc123',
             'is_superuser': 1,
             'cert_cn': '{} test user five'.format(ut_id(gvar, 'group')),
-            'group_name.1': ut_id(gvar, 'gtg4'),
-            'group_name.2': ut_id(gvar, 'gtg5'),
+            'group_name.1': ut_id(gvar, 'gtg5'),
             'group_name.2': ut_id(gvar, 'gtg6')
         }
     )

--- a/unit_tests/group_requests_setup.py
+++ b/unit_tests/group_requests_setup.py
@@ -119,16 +119,6 @@ def main(gvar):
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
-
-    execute_csv2_request(
-        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5.json')),
-        '/group/metadata-add/', form_data={
-            'group': ut_id(gvar, 'gtg5'),
-            'metadata_name': ut_id(gvar, 'gty5.json'),
-            'metadata': '{"example":"json"}'
-        },
-        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    )
     
     # unprivileged user to be added to groups
     execute_csv2_request(

--- a/unit_tests/group_requests_setup.py
+++ b/unit_tests/group_requests_setup.py
@@ -109,6 +109,26 @@ def main(gvar):
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5.yaml')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg5'),
+            'metadata_name': ut_id(gvar, 'gty5.yaml'),
+            'metadata': '- example: yaml'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5.json')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg5'),
+            'metadata_name': ut_id(gvar, 'gty5.json'),
+            'metadata': '{"example":"json"}'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
     
     # unprivileged user to be added to groups
     execute_csv2_request(

--- a/unit_tests/run_tests
+++ b/unit_tests/run_tests
@@ -11,55 +11,72 @@ from re import sub
 import sys
 import user_requests_setup
 import user_requests_cleanup
+import group_requests_setup
+import group_requests_cleanup
 
 def get_test_list():
-    test_files = []
-    test_names = []
+    user_test_files = []
+    user_test_names = []
+    group_test_files = []
+    group_test_names = []
     for f in sorted(listdir('.')):
-        if f.startswith('test'):
-            test_files.append(f[:-3])
-            test_names.append(sub(r'\d', '', f[5:-3]))
-    return test_names, test_files
+        if f.startswith('test_user'):
+            user_test_files.append(f[:-3])
+            user_test_names.append(sub(r'\d', '', f[5:-3]))
+        if f.startswith('test_group'):
+            group_test_files.append(f[:-3])
+            group_test_names.append(sub(r'\d', '', f[5:-3]))
+    return user_test_names, user_test_files, group_test_names, group_test_files
 
 def main():
-    test_names, test_files = get_test_list()
+    ut_names, ut_files, gt_names, gt_files = get_test_list()
     options = []
     setup = True
     cleanup = True
+    hidden = True
     selections = ''
+    tests_present = {'user': False, 'group': False}
     if len(sys.argv) > 1:
         for arg in sys.argv[1:]:
             if arg == '-h' or arg == '--help':
                 print('Options:')
                 print('-ss | --skip-setup\tFlag to specify if unit test setup should be skipped')
                 print('-sc | --skip-cleanup\tFlag to specify if unit test cleanup should be skipped')
+                print('-v | --verbose\tPrint setup and clean up output')
                 print('The valid tests in this folder are:')
-                print('\n'.join(test_names))
+                print('\n'.join(ut_names))
+                print('\n'.join(gt_names))
                 exit()
             elif arg == '-ss' or arg == '--skip-setup':
                 setup = False
             elif arg == '-sc' or arg == '--skip-cleanup':
                 cleanup = False
+            elif arg == '-v':
+                hidden = False
             elif arg.startswith('['):
                 selections = arg[1:-1]
             elif arg.endswith(']'):
                 temp = arg.split('[')
-                if temp[0] not in test_names:
+                if temp[0] not in ut_names and temp[0] not in gt_names:
                     print('Error: {} is not a valid test group. For a list of valid tests run command with the "-h" option.'.format(temp[0]))
                     exit(1)
                 option = (temp[0], {})
                 initialize_csv2_request(option[1], sys.argv[0], selections=temp[1][:-1])
                 options.append(option)
             else:
-                if arg not in test_names:
+                if arg not in ut_names and arg not in gt_names:
                     print('Error: {} is not a valid test group. For a list of valid tests run command with the "-h" option.'.format(arg))
                     exit(1)
                 option = (arg, {})
                 initialize_csv2_request(option[1], sys.argv[0])
                 options.append(option)
+            if arg.startswith('user'):
+                tests_present['user'] = True
+            elif arg.startswith('group'):
+                tests_present['group'] = True
     
     hidden_gvar = {}
-    initialize_csv2_request(hidden_gvar, sys.argv[0], hidden=True)
+    initialize_csv2_request(hidden_gvar, sys.argv[0], hidden=hidden)
     
     if len(options) == 0:
         gvar = {}
@@ -67,29 +84,59 @@ def main():
             initialize_csv2_request(gvar, sys.argv[0])
         else:
             initialize_csv2_request(gvar, sys.argv[0], selections=selections)
+        # User Tests
         if setup:
             print('Setting up user tests...')
             user_requests_setup.main(hidden_gvar)
-        for i in range(len(test_names)):
-            exec('import {}'.format(test_files[i]), globals(), locals())
-            print('\n*** Testing {} ***\n'.format(test_names[i]))
-            exec('{}.main(gvar)'.format(test_files[i]), globals(), locals())
+        for i in range(len(ut_names)):
+            exec('import {}'.format(ut_files[i]), globals(), locals())
+            print('\n*** Testing {} ***\n'.format(ut_names[i]))
+            exec('{}.main(gvar)'.format(ut_files[i]), globals(), locals())
         if cleanup:
             print('Cleaning up user tests...')
             user_requests_cleanup.main(hidden_gvar)
+        # Group Tests
+        if setup:
+            print('Setting up group tests...')
+            group_requests_setup.main(hidden_gvar)
+        for i in range(len(gt_names)):
+            exec('import {}'.format(gt_files[i]), globals(), locals())
+            print('\n*** Testing {} ***\n'.format(gt_names[i]))
+            exec('{}.main(gvar)'.format(gt_files[i]), globals(), locals())
+        if cleanup:
+            print('Cleaning up group tests...')
+            group_requests_cleanup.main(hidden_gvar)
+
         print('Test run=%s, skipped=%s, failed=%s.' % (gvar['ut_count']-gvar['ut_skipped'], gvar['ut_skipped'], gvar['ut_failed']))
         exit(gvar['ut_failed'])
     else:
-        if setup:
-            print('Setting up user tests...')
-            user_requests_setup.main(hidden_gvar)
-        for o, g in options:
-            exec('import {}'.format(test_files[test_names.index(o)]), globals(), locals())
-            print('\n*** Testing {} ***\n'.format(o))
-            exec('{}.main(g)'.format(test_files[test_names.index(o)]), globals(), locals())
-        if cleanup:
-            print('Cleaning up user tests...')
-            user_requests_cleanup.main(hidden_gvar)
+        # User Tests
+        if tests_present['user']:
+            if setup:
+                print('Setting up user tests...')
+                user_requests_setup.main(hidden_gvar)
+            for o, g in options:
+                if o.startswith('user'):
+                    exec('import {}'.format(ut_files[ut_names.index(o)]), globals(), locals())
+                    print('\n*** Testing {} ***\n'.format(o))
+                    exec('{}.main(g)'.format(ut_files[ut_names.index(o)]), globals(), locals())
+            if cleanup:
+                print('Cleaning up user tests...')
+                user_requests_cleanup.main(hidden_gvar)
+        # Group Tests
+        if tests_present['group']:
+            if setup:
+                print('Setting up group tests...')
+                group_requests_setup.main(hidden_gvar)
+            for o, g in options:
+                if o.startswith('group'):
+                    exec('import {}'.format(gt_files[gt_names.index(o)]), globals(), locals())
+                    print('\n*** Testing {} ***\n'.format(o))
+                    exec('{}.main(g)'.format(gt_files[gt_names.index(o)]), globals(), locals())
+            if cleanup:
+                print('Cleaning up group tests...')
+                group_requests_cleanup.main(hidden_gvar)
+
         for o, g in options:
             print('Test {} run={}, skipped={}, failed={}.'.format(o, g['ut_count']-g['ut_skipped'], g['ut_skipped'], g['ut_failed']))
 

--- a/unit_tests/run_tests
+++ b/unit_tests/run_tests
@@ -9,136 +9,121 @@ from os import listdir
 from re import sub
 
 import sys
-import user_requests_setup
-import user_requests_cleanup
-import group_requests_setup
-import group_requests_cleanup
+
+TEST_OBJECTS = ['user', 'group']
 
 def get_test_list():
-    user_test_files = []
-    user_test_names = []
-    group_test_files = []
-    group_test_names = []
+    test_names = []
     for f in sorted(listdir('.')):
-        if f.startswith('test_user'):
-            user_test_files.append(f[:-3])
-            user_test_names.append(sub(r'\d', '', f[5:-3]))
-        if f.startswith('test_group'):
-            group_test_files.append(f[:-3])
-            group_test_names.append(sub(r'\d', '', f[5:-3]))
-    return user_test_names, user_test_files, group_test_names, group_test_files
+        if f.startswith('test_'):
+            test_names.append((f[:-3],sub(r'\d', '', f[5:-3])))
+    return test_names
 
 def main():
-    ut_names, ut_files, gt_names, gt_files = get_test_list()
-    options = []
-    setup = True
-    cleanup = True
-    hidden = True
-    selections = ''
-    tests_present = {'user': False, 'group': False}
+    test_names = get_test_list()
+    user_options = {
+        'setup': True,
+        'cleanup': True,
+        'hidden': True,
+        'run_all': True,
+        'tests': [],
+        'objects': []
+    }
+
     if len(sys.argv) > 1:
         for arg in sys.argv[1:]:
             if arg == '-h' or arg == '--help':
-                print('Options:')
-                print('-ss | --skip-setup\tFlag to specify if unit test setup should be skipped')
-                print('-sc | --skip-cleanup\tFlag to specify if unit test cleanup should be skipped')
-                print('-v | --verbose\tPrint setup and clean up output')
-                print('The valid tests in this folder are:')
-                print('\n'.join(ut_names))
-                print('\n'.join(gt_names))
-                exit()
+                    print('Options:')
+                    print('-ss | --skip-setup\tFlag to specify if unit test setup should be skipped')
+                    print('-sc | --skip-cleanup\tFlag to specify if unit test cleanup should be skipped')
+                    print('-v  | --verbose\t\tPrint setup and clean up output')
+                    print('The valid tests in this folder are:')
+                    for (_, name) in test_names:
+                        print(name)
+                    exit()
             elif arg == '-ss' or arg == '--skip-setup':
-                setup = False
+                user_options['setup'] = False
             elif arg == '-sc' or arg == '--skip-cleanup':
-                cleanup = False
-            elif arg == '-v':
-                hidden = False
+                user_options['cleanup'] = False
+            elif arg == '-v' or arg == '--verbose':
+                user_options['hidden'] = False
             elif arg.startswith('['):
-                selections = arg[1:-1]
-            elif arg.endswith(']'):
-                temp = arg.split('[')
-                if temp[0] not in ut_names and temp[0] not in gt_names:
-                    print('Error: {} is not a valid test group. For a list of valid tests run command with the "-h" option.'.format(temp[0]))
-                    exit(1)
-                option = (temp[0], {})
-                initialize_csv2_request(option[1], sys.argv[0], selections=temp[1][:-1])
-                options.append(option)
+                user_options['run_all_selection'] = arg[1:-1]
             else:
-                if arg not in ut_names and arg not in gt_names:
-                    print('Error: {} is not a valid test group. For a list of valid tests run command with the "-h" option.'.format(arg))
-                    exit(1)
-                option = (arg, {})
-                initialize_csv2_request(option[1], sys.argv[0])
-                options.append(option)
-            if arg.startswith('user'):
-                tests_present['user'] = True
-            elif arg.startswith('group'):
-                tests_present['group'] = True
+                user_options['run_all'] = False
+                if arg.endswith(']'):
+                    temp = arg.split('[')
+                    selection = temp[1][:-1]
+                    obj = temp[0]
+                else:
+                    obj = arg
+                    selection = None
+                if obj in TEST_OBJECTS:
+                    user_options['run_all'] = False
+                    filtered_tests = [test for test in test_names if test[1].startswith(obj)]
+                    for test in filtered_tests:
+                        option = (test, {})
+                        initialize_csv2_request(option[1], sys.argv[0], selections=selection)
+                        user_options['tests'].append(option)
+                    if obj not in user_options['objects']:
+                        user_options['objects'].append(obj)
+                else:
+                    test_found = [i for i, test in enumerate(test_names) if test[1] == obj]
+                    if test_found == []:
+                        print('No test of the name "{}". Run with the "-h" flag for a list of valid tests'.format(obj))
+                        exit()
+                    else:
+                        option = (test_names[test_found[0]], {})
+                        initialize_csv2_request(option[1], sys.argv[0], selections=selection)
+                        user_options['tests'].append(option)
+                        for o in TEST_OBJECTS:
+                            if obj.startswith(o) and o not in user_options['objects']:
+                                user_options['objects'].append(o)
+    
+    if user_options['run_all']:
+        for test in test_names:
+            user_options['tests'].append((test, None))
+        user_options['objects'] = TEST_OBJECTS
+
+    # print(user_options)
     
     hidden_gvar = {}
-    initialize_csv2_request(hidden_gvar, sys.argv[0], hidden=hidden)
+    initialize_csv2_request(hidden_gvar, sys.argv[0], hidden=user_options['hidden'])
     
-    if len(options) == 0:
-        gvar = {}
-        if selections == '':
-            initialize_csv2_request(gvar, sys.argv[0])
-        else:
-            initialize_csv2_request(gvar, sys.argv[0], selections=selections)
-        # User Tests
-        if setup:
-            print('Setting up user tests...')
-            user_requests_setup.main(hidden_gvar)
-        for i in range(len(ut_names)):
-            exec('import {}'.format(ut_files[i]), globals(), locals())
-            print('\n*** Testing {} ***\n'.format(ut_names[i]))
-            exec('{}.main(gvar)'.format(ut_files[i]), globals(), locals())
-        if cleanup:
-            print('Cleaning up user tests...')
-            user_requests_cleanup.main(hidden_gvar)
-        # Group Tests
-        if setup:
-            print('Setting up group tests...')
-            group_requests_setup.main(hidden_gvar)
-        for i in range(len(gt_names)):
-            exec('import {}'.format(gt_files[i]), globals(), locals())
-            print('\n*** Testing {} ***\n'.format(gt_names[i]))
-            exec('{}.main(gvar)'.format(gt_files[i]), globals(), locals())
-        if cleanup:
-            print('Cleaning up group tests...')
-            group_requests_cleanup.main(hidden_gvar)
-
+    gvar = {}
+    if 'run_all_selection' in user_options.keys():
+        initialize_csv2_request(gvar, sys.argv[0], selections=user_options['run_all_selection'])
+    else:
+        initialize_csv2_request(gvar, sys.argv[0])
+    
+    for obj in user_options['objects']:
+        if user_options['setup']:
+            exec('import {}_requests_setup'.format(obj), globals(), locals())
+            print('Setting up {} tests...'.format(obj))
+            exec('{}_requests_setup.main(hidden_gvar)'.format(obj), globals(), locals())
+        for ((f, n), s) in user_options['tests']:
+            if s == None:
+                if n.startswith(obj):
+                    exec('import {}'.format(f), globals(), locals())
+                    print('\n*** Testing {} ***\n'.format(n))
+                    exec('{}.main(gvar)'.format(f), globals(), locals())
+            else:
+                if n.startswith(obj):
+                    exec('import {}'.format(f), globals(), locals())
+                    print('\n*** Testing {} ***\n'.format(n))
+                    exec('{}.main(s)'.format(f), globals(), locals())
+        if user_options['cleanup']:
+            exec('import {}_requests_cleanup'.format(obj))
+            print('Cleaning up {} tests...'.format(obj))
+            exec('{}_requests_cleanup.main(hidden_gvar)'.format(obj), globals(), locals())
+    if user_options['run_all']:
         print('Test run=%s, skipped=%s, failed=%s.' % (gvar['ut_count']-gvar['ut_skipped'], gvar['ut_skipped'], gvar['ut_failed']))
         exit(gvar['ut_failed'])
-    else:
-        # User Tests
-        if tests_present['user']:
-            if setup:
-                print('Setting up user tests...')
-                user_requests_setup.main(hidden_gvar)
-            for o, g in options:
-                if o.startswith('user'):
-                    exec('import {}'.format(ut_files[ut_names.index(o)]), globals(), locals())
-                    print('\n*** Testing {} ***\n'.format(o))
-                    exec('{}.main(g)'.format(ut_files[ut_names.index(o)]), globals(), locals())
-            if cleanup:
-                print('Cleaning up user tests...')
-                user_requests_cleanup.main(hidden_gvar)
-        # Group Tests
-        if tests_present['group']:
-            if setup:
-                print('Setting up group tests...')
-                group_requests_setup.main(hidden_gvar)
-            for o, g in options:
-                if o.startswith('group'):
-                    exec('import {}'.format(gt_files[gt_names.index(o)]), globals(), locals())
-                    print('\n*** Testing {} ***\n'.format(o))
-                    exec('{}.main(g)'.format(gt_files[gt_names.index(o)]), globals(), locals())
-            if cleanup:
-                print('Cleaning up group tests...')
-                group_requests_cleanup.main(hidden_gvar)
-
-        for o, g in options:
-            print('Test {} run={}, skipped={}, failed={}.'.format(o, g['ut_count']-g['ut_skipped'], g['ut_skipped'], g['ut_failed']))
+    
+    for ((_, n), s) in user_options['tests']:
+        print('Test {} run={}, skipped={}, failed={}.'.format(n, s['ut_count']-s['ut_skipped'], s['ut_skipped'], s['ut_failed']))
+    
+    
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_group_add.py
+++ b/unit_tests/test_group_add.py
@@ -33,7 +33,7 @@ def main(gvar):
 
     execute_csv2_request(
         gvar, 1, 'GV01', 'request did not contain mandatory parameter "group_name".',
-        '/group/add/', form_data={'group': 'testing'}
+        '/group/add/', form_data={'condor_central_manager': 'invalid-unit-test'}
     )
 
     execute_csv2_request(

--- a/unit_tests/test_group_add.py
+++ b/unit_tests/test_group_add.py
@@ -128,24 +128,6 @@ def main(gvar):
         }
     )
 
-    # execute_csv2_request(
-    #     gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
-    #     '/group/add/', form_data={
-    #         'group_name': ut_id(gvar, 'gtg3'),
-    #         'condor_central_manager': 'unit-test-group-three.ca',
-    #         'job_cpus': -1
-    #     }
-    # )
-
-    # execute_csv2_request(
-    #     gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
-    #     '/group/add/', form_data={
-    #         'group_name': ut_id(gvar, 'gtg3'),
-    #         'condor_central_manager': 'unit-test-group-three.ca',
-    #         'job_cpus': 1.2345
-    #     }
-    # )
-
     execute_csv2_request(
         gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_ram\' at row 1',
         '/group/add/', form_data={

--- a/unit_tests/test_group_add.py
+++ b/unit_tests/test_group_add.py
@@ -1,0 +1,202 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    execute_csv2_request(
+        gvar, 1, 'GV04', 'invalid method "GET" specified.',
+        '/group/add/'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/add/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'user "{}" is not a member of any group.'.format(ut_id(gvar, 'gtu2')),
+        '/group/add/',
+        server_user=ut_id(gvar, 'gtu2'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/add/', form_data={'group': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV01', 'request did not contain mandatory parameter "group_name".',
+        '/group/add/', form_data={'group': 'testing'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV01', 'request contained a bad parameter "invalid-unit-test".',
+        '/group/add/', form_data={'invalid-unit-test': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV01', 'value specified for "group_name" must be all lower case, numeric digits, and dashes but cannot start or end with dashes.',
+        '/group/add/', form_data={'group_name': ut_id(gvar, 'Gtg1')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV01', 'value specified for "group_name" must be all lower case, numeric digits, and dashes but cannot start or end with dashes.',
+        '/group/add/', form_data={'group_name': ut_id(gvar, 'gtg1-')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV01', 'value specified for "group_name" must be all lower case, numeric digits, and dashes but cannot start or end with dashes.',
+        '/group/add/', form_data={'group_name': ut_id(gvar, 'gtg!1')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV02', 'Data too long for column \'group_name\' at row 1',
+        '/group/add/', form_data={'group_name': ut_id(gvar, 'thisisagroupnametoolongtoinsertintothedatabasethisisagroupnametoolongtoinsertintothedatabasethisisagroupnametoolongtoinsertintothedatabase')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV97', '"{}" failed - specified user "invalid-unit-test" does not exist.'.format(ut_id(gvar, 'gtg1')),
+        '/group/add/', form_data={
+            'username.1': 'invalid-unit-test',
+            'group_name': ut_id(gvar, 'gtg1')
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV01', 'value specified for "user_option" must be one of the following options: [\'add\', \'delete\'].',
+        '/group/add/', form_data={
+            'user_option': 'invalid-unit-test',
+            'group_name': ut_id(gvar, 'gtg1')
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully added.'.format(ut_id(gvar, 'gtg1')),
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg1'),
+            'username.1': ut_id(gvar, 'gtu3')
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/list/',
+        list='group_list', filter={'group_name': ut_id(gvar, 'gtg1')},
+        values={'group_name': ut_id(gvar, 'gtg1'), 'metadata_names': None, 'condor_central_manager': None}
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/user/list/',
+        list='user_list', filter={'username': ut_id(gvar, 'gtu3')},
+        values={'username': ut_id(gvar, 'gtu3'), 'user_groups': ut_id(gvar, 'gtg1,gtg4,gtg5')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV02', '"{0}" failed - (1062, "Duplicate entry \'{0}\' for key \'PRIMARY\'").'.format(ut_id(gvar, 'gtg1')),
+        '/group/add/', form_data={'group_name': ut_id(gvar, 'gtg1')}
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully added.'.format(ut_id(gvar, 'gtg2')),
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg2'),
+            'condor_central_manager': 'unit-test-group-two.ca'
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/list/',
+        list='group_list', filter={'group_name': ut_id(gvar, 'gtg2')},
+        values={'group_name': ut_id(gvar, 'gtg2'), 'metadata_names': None, 'condor_central_manager': 'unit-test-group-two.ca'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg3'),
+            'condor_central_manager': 'unit-test-group-three.ca',
+            'job_cpus': 'invalid-unit-test'
+        }
+    )
+
+    # execute_csv2_request(
+    #     gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
+    #     '/group/add/', form_data={
+    #         'group_name': ut_id(gvar, 'gtg3'),
+    #         'condor_central_manager': 'unit-test-group-three.ca',
+    #         'job_cpus': -1
+    #     }
+    # )
+
+    # execute_csv2_request(
+    #     gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
+    #     '/group/add/', form_data={
+    #         'group_name': ut_id(gvar, 'gtg3'),
+    #         'condor_central_manager': 'unit-test-group-three.ca',
+    #         'job_cpus': 1.2345
+    #     }
+    # )
+
+    execute_csv2_request(
+        gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_ram\' at row 1',
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg3'),
+            'condor_central_manager': 'unit-test-group-three.ca',
+            'job_ram': 'invalid-unit-test'
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_disk\' at row 1',
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg3'),
+            'condor_central_manager': 'unit-test-group-three.ca',
+            'job_disk': 'invalid-unit-test'
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_scratch\' at row 1',
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg3'),
+            'condor_central_manager': 'unit-test-group-three.ca',
+            'job_scratch': 'invalid-unit-test'
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV03', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_swap\' at row 1',
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg3'),
+            'condor_central_manager': 'unit-test-group-three.ca',
+            'job_swap': 'invalid-unit-test'
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully added.'.format(ut_id(gvar, 'gtg3')),
+        '/group/add/', form_data={
+            'group_name': ut_id(gvar, 'gtg3'),
+            'condor_central_manager': 'unit-test-group-three.ca',
+            'job_cpus': 1,
+            'job_ram': 1,
+            'job_disk': 1,
+            'job_scratch': 1,
+            'job_swap': 1
+        }
+    )
+
+
+    
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_defaults.py
+++ b/unit_tests/test_group_defaults.py
@@ -28,87 +28,91 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV07', 'cannot switch to invalid group "invalid-unit-test".',
         '/group/defaults/', form_data={'group': 'invalid-unit-test'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV07', 'cannot switch to invalid group "testing".',
         '/group/defaults/', form_data={'group': 'testing'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
+    # TODO: better error message??
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV05', 'group defaults update "{}" failed'.format(ut_id(gvar, 'gtg4')),
         '/group/defaults/', form_data={'group': ut_id(gvar, 'gtg4')},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
     execute_csv2_request(
-        gvar, 1, None, '???',
+        gvar, 1, 'GV06', 'request contained a bad parameter "invalid-unit-test".',
         '/group/defaults/', form_data={'invalid-unit-test': 'invalid-unit-test'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
+    # TODO: better error message??
     execute_csv2_request(
-        gvar, 1, None, '???',
+        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
         '/group/defaults/', form_data={
-            'group_name': ut_id(gvar, 'gtg4'),
+            'group': ut_id(gvar, 'gtg4'),
             'job_cpus': 'invalid-unit-test'
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # execute_csv2_request(
-    #     gvar, 1, None, '???',
-    #     '/group/defaults/', form_data={
-    #         'group_name': ut_id(gvar, 'gtg4'),
-    #         'job_cpus': -1
-    #     },
-    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    # )
+    # TODO: should this fail??
+    execute_csv2_request(
+        gvar, 0, None, '"{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
+        '/group/defaults/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'job_cpus': -1
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
 
-    # execute_csv2_request(
-    #     gvar, 1, None, '???',
-    #     '/group/defaults/', form_data={
-    #         'group_name': ut_id(gvar, 'gtg4'),
-    #         'job_cpus': 1.2345
-    #     },
-    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    # )
+    # TODO: should this fail??
+    execute_csv2_request(
+        gvar, 0, None, '"{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
+        '/group/defaults/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'job_cpus': 1.2345
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
 
     execute_csv2_request(
-        gvar, 1, None, '???',
+        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_ram\' at row 1',
         '/group/defaults/', form_data={
-            'group_name': ut_id(gvar, 'gtg4'),
+            'group': ut_id(gvar, 'gtg4'),
             'job_ram': 'invalid-unit-test'
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
     execute_csv2_request(
-        gvar, 1, None, '???',
+        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_disk\' at row 1',
         '/group/defaults/', form_data={
-            'group_name': ut_id(gvar, 'gtg4'),
+            'group': ut_id(gvar, 'gtg4'),
             'job_disk': 'invalid-unit-test'
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
     execute_csv2_request(
-        gvar, 1, None, '???',
+        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_scratch\' at row 1',
         '/group/defaults/', form_data={
-            'group_name': ut_id(gvar, 'gtg4'),
+            'group': ut_id(gvar, 'gtg4'),
             'job_scratch': 'invalid-unit-test'
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
     execute_csv2_request(
-        gvar, 1, None, '???',
+        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_swap\' at row 1',
         '/group/defaults/', form_data={
-            'group_name': ut_id(gvar, 'gtg4'),
+            'group': ut_id(gvar, 'gtg4'),
             'job_swap': 'invalid-unit-test'
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
@@ -117,7 +121,7 @@ def main(gvar):
     execute_csv2_request(
         gvar, 0, None, '"{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
         '/group/defaults/', form_data={
-            'group_name': ut_id(gvar, 'gtg4'),
+            'group': ut_id(gvar, 'gtg4'),
             'job_cpus': 1,
             'job_ram': 1,
             'job_disk': 1,

--- a/unit_tests/test_group_defaults.py
+++ b/unit_tests/test_group_defaults.py
@@ -1,0 +1,131 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/defaults/',
+        server_user=ut_id(gvar, 'invalid-unit-test'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV07', 'user "{}" is not a member of any group.'.format(ut_id(gvar, 'gtu1')),
+        '/group/defaults/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/defaults/',
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/defaults/', form_data={'group': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/defaults/', form_data={'group': 'testing'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/defaults/', form_data={'group': ut_id(gvar, 'gtg4')},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, '???',
+        '/group/defaults/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, '???',
+        '/group/defaults/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'job_cpus': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    # execute_csv2_request(
+    #     gvar, 1, None, '???',
+    #     '/group/defaults/', form_data={
+    #         'group_name': ut_id(gvar, 'gtg4'),
+    #         'job_cpus': -1
+    #     },
+    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    # )
+
+    # execute_csv2_request(
+    #     gvar, 1, None, '???',
+    #     '/group/defaults/', form_data={
+    #         'group_name': ut_id(gvar, 'gtg4'),
+    #         'job_cpus': 1.2345
+    #     },
+    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    # )
+
+    execute_csv2_request(
+        gvar, 1, None, '???',
+        '/group/defaults/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'job_ram': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, '???',
+        '/group/defaults/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'job_disk': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, '???',
+        '/group/defaults/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'job_scratch': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, '???',
+        '/group/defaults/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'job_swap': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, '"{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
+        '/group/defaults/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'job_cpus': 1,
+            'job_ram': 1,
+            'job_disk': 1,
+            'job_scratch': 1,
+            'job_swap': 1
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_defaults.py
+++ b/unit_tests/test_group_defaults.py
@@ -39,7 +39,6 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: better error message??
     execute_csv2_request(
         gvar, 1, 'GV05', 'group defaults update "{}" failed'.format(ut_id(gvar, 'gtg4')),
         '/group/defaults/', form_data={'group': ut_id(gvar, 'gtg4')},
@@ -52,32 +51,11 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: better error message??
     execute_csv2_request(
         gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
         '/group/defaults/', form_data={
             'group': ut_id(gvar, 'gtg4'),
             'job_cpus': 'invalid-unit-test'
-        },
-        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    )
-
-    # TODO: should this fail??
-    execute_csv2_request(
-        gvar, 0, None, '"{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
-        '/group/defaults/', form_data={
-            'group': ut_id(gvar, 'gtg4'),
-            'job_cpus': -1
-        },
-        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    )
-
-    # TODO: should this fail??
-    execute_csv2_request(
-        gvar, 0, None, '"{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
-        '/group/defaults/', form_data={
-            'group': ut_id(gvar, 'gtg4'),
-            'job_cpus': 1.2345
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )

--- a/unit_tests/test_group_defaults.py
+++ b/unit_tests/test_group_defaults.py
@@ -52,7 +52,7 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_cpus\' at row 1',
+        gvar, 1, 'GV06', 'group defaults update value specified for "job_cpus" must be a integer value.',
         '/group/defaults/', form_data={
             'group': ut_id(gvar, 'gtg4'),
             'job_cpus': 'invalid-unit-test'
@@ -61,7 +61,7 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_ram\' at row 1',
+        gvar, 1, 'GV06', 'group defaults update value specified for "job_ram" must be a integer value.',
         '/group/defaults/', form_data={
             'group': ut_id(gvar, 'gtg4'),
             'job_ram': 'invalid-unit-test'
@@ -70,7 +70,7 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_disk\' at row 1',
+        gvar, 1, 'GV06', 'group defaults update value specified for "job_disk" must be a integer value.',
         '/group/defaults/', form_data={
             'group': ut_id(gvar, 'gtg4'),
             'job_disk': 'invalid-unit-test'
@@ -79,7 +79,7 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_scratch\' at row 1',
+        gvar, 1, 'GV06', 'group defaults update value specified for "job_scratch" must be a integer value.',
         '/group/defaults/', form_data={
             'group': ut_id(gvar, 'gtg4'),
             'job_scratch': 'invalid-unit-test'
@@ -88,7 +88,7 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, 'GV05', 'Incorrect integer value: \'invalid-unit-test\' for column \'job_swap\' at row 1',
+        gvar, 1, 'GV06', 'group defaults update value specified for "job_swap" must be a integer value.',
         '/group/defaults/', form_data={
             'group': ut_id(gvar, 'gtg4'),
             'job_swap': 'invalid-unit-test'

--- a/unit_tests/test_group_delete.py
+++ b/unit_tests/test_group_delete.py
@@ -42,5 +42,33 @@ def main(gvar):
         '/group/delete/', form_data={'group': 'invalid-unit-test'}
     )
 
+    # TODO: returns 500 code
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/delete/', form_data={'group': ut_id(gvar, 'gtg6')},
+        server_user=ut_id(gvar, 'gtu5'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV20', 'group delete "invalid-unit-test" failed - the request did not match any rows.',
+        '/group/delete/', form_data={'group_name': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV09', 'group delete value specified for "group_name" must be all lower case, numeric digits, and dashes but cannot start or end with dashes.',
+        '/group/delete/', form_data={'group_name': 'Invalid-Unit-Test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV09', 'group delete value specified for "user_option" must be one of the following options: [\'add\', \'delete\'].',
+        '/group/delete/', form_data={'user_option': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully deleted.'.format(ut_id(gvar, 'gtg6')),
+        '/group/delete/', form_data={'group': ut_id(gvar, 'gtg6'), 'group_name': ut_id(gvar, 'gtg6')},
+        server_user=ut_id(gvar, 'gtu5'), server_pw='Abc123'
+    )
+
 if __name__ == "__main__":
     main(None)

--- a/unit_tests/test_group_delete.py
+++ b/unit_tests/test_group_delete.py
@@ -1,0 +1,46 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/delete/',
+        server_user=ut_id(gvar, 'invalid-unit-test'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'user "{}" is not a member of any group.'.format(ut_id(gvar, 'gtu2')),
+        '/group/delete/',
+        server_user=ut_id(gvar, 'gtu2'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/delete/',
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV21', 'invalid method "GET" specified.',
+        '/group/delete/'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV09', 'request contained a bad parameter "invalid-unit-test".',
+        '/group/delete/', form_data={'invalid-unit-test': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV08', 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/delete/', form_data={'group': 'invalid-unit-test'}
+    )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_delete.py
+++ b/unit_tests/test_group_delete.py
@@ -42,9 +42,8 @@ def main(gvar):
         '/group/delete/', form_data={'group': 'invalid-unit-test'}
     )
 
-    # TODO: returns 500 code
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV09', 'group delete request did not contain mandatory parameter "group_name".',
         '/group/delete/', form_data={'group': ut_id(gvar, 'gtg6')},
         server_user=ut_id(gvar, 'gtu5'), server_pw='Abc123'
     )

--- a/unit_tests/test_group_list.py
+++ b/unit_tests/test_group_list.py
@@ -1,0 +1,41 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/list/',
+        server_user='invalid-unit-test', server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/list/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'user "{}" is not a member of any group.'.format(ut_id(gvar, 'gtu2')),
+        '/group/list/',
+        server_user=ut_id(gvar, 'gtu2'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/list/', form_data={'group': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/list/'
+    )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_metadata_add.py
+++ b/unit_tests/test_group_metadata_add.py
@@ -98,7 +98,6 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: better error message??
     execute_csv2_request(
         gvar, 1, 'GV28', 'Incorrect integer value: \'invalid-unit-test\' for column \'priority\' at row 1',
         '/group/metadata-add/', form_data={

--- a/unit_tests/test_group_metadata_add.py
+++ b/unit_tests/test_group_metadata_add.py
@@ -112,13 +112,13 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, '???', 'invalid yaml file',
+        gvar, 1, 'GV27', 'yaml value specified for "metadata (metadata_name)" is invalid - scanner error',
         '/group/metadata-add/', form_data={
             'group': ut_id(gvar, 'gtg4'),
             'metadata_name': 'invalid-unit-test.yaml',
             'enabled': 0,
             'mime_type': 'cloud-config',
-            'metadata': '{"invalid-unit-test":"yes"}',
+            'metadata': 'foo: somebody said I should put a colon here: so I did',
             'priority': 1
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'

--- a/unit_tests/test_group_metadata_add.py
+++ b/unit_tests/test_group_metadata_add.py
@@ -125,13 +125,13 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, '???', 'invalid json file',
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty1')),
         '/group/metadata-add/', form_data={
-            'group': ut_id(gvar, 'gtg4'),
-            'metadata_name': 'invalid-unit-test.json',
+            'group': ut_id(gvar, 'gtg5'),
+            'metadata_name': ut_id(gvar, 'gty1'),
             'enabled': 0,
             'mime_type': 'cloud-config',
-            'metadata': '- invalid-unit-test: yes',
+            'metadata': '{"not-yaml":"yes"}',
             'priority': 1
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
@@ -188,27 +188,6 @@ def main(gvar):
         '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
         list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty1.yaml')},
         values={'metadata_name': ut_id(gvar, 'gty1.yaml'), 'enabled': 0, 'metadata': '- example: yaml', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 1, 'mime_type': 'cloud-config'},
-        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    )
-
-    execute_csv2_request(
-        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty1.json')),
-        '/group/metadata-add/', form_data={
-            'group': ut_id(gvar, 'gtg5'),
-            'metadata_name': ut_id(gvar, 'gty1.json'),
-            'enabled': 0,
-            'mime_type': 'cloud-config',
-            'metadata': '{"example":"json"}',
-            'priority': 1
-        },
-        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    )
-
-    execute_csv2_request(
-        gvar, 0, None, None,
-        '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
-        list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty1.json')},
-        values={'metadata_name': ut_id(gvar, 'gty1.json'), 'enabled': 0, 'metadata': '{"example":"json"}', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 1, 'mime_type': 'cloud-config'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 

--- a/unit_tests/test_group_metadata_add.py
+++ b/unit_tests/test_group_metadata_add.py
@@ -34,7 +34,7 @@ def main(gvar):
     )
     
     execute_csv2_request(
-        gvar, 1, 'GV30', 'no group name specified.',
+        gvar, 1, 'GV30', 'no metadata name specified.',
         '/group/metadata-add/', form_data={'invalid-unit-test': 'invalid-unit-test'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
@@ -111,25 +111,37 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: I thought files with .yaml endings were being validated as yaml??
-    # execute_csv2_request(
-    #     gvar, 1, '???', '???',
-    #     '/group/metadata-add/', form_data={
-    #         'group': ut_id(gvar, 'gtg4'),
-    #         'metadata_name': 'invalid-unit-test.yaml',
-    #         'enabled': 0,
-    #         'mime_type': 'cloud-config',
-    #         'metadata': '{"invalid-unit-test":"yes"}',
-    #         'priority': 1
-    #     },
-    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    # )
-
     execute_csv2_request(
-        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg4'), ut_id(gvar, 'gty1')),
+        gvar, 1, '???', 'invalid yaml file',
         '/group/metadata-add/', form_data={
             'group': ut_id(gvar, 'gtg4'),
-            'metadata_name': ut_id(gvar, 'gty1'),
+            'metadata_name': 'invalid-unit-test.yaml',
+            'enabled': 0,
+            'mime_type': 'cloud-config',
+            'metadata': '{"invalid-unit-test":"yes"}',
+            'priority': 1
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', 'invalid json file',
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': 'invalid-unit-test.json',
+            'enabled': 0,
+            'mime_type': 'cloud-config',
+            'metadata': '- invalid-unit-test: yes',
+            'priority': 1
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg4'), ut_id(gvar, 'gty1.yaml')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': ut_id(gvar, 'gty1.yaml'),
             'enabled': 0,
             'mime_type': 'cloud-config',
             'metadata': '- example: metadata',
@@ -142,14 +154,14 @@ def main(gvar):
         gvar, 0, None, None,
         '/group/list/',
         list='group_list', filter={'group_name': ut_id(gvar, 'gtg4')},
-        values={'group_name': ut_id(gvar, 'gtg4'), 'metadata_names': ut_id(gvar, 'gty1')}
+        values={'group_name': ut_id(gvar, 'gtg4'), 'metadata_names': ut_id(gvar, 'gty1.yaml')}
     )
 
     execute_csv2_request(
-        gvar, 1, 'GV28', 'Duplicate entry \'{}-{}\' for key \'PRIMARY\''.format(ut_id(gvar, 'gtg4'), ut_id(gvar, 'gty1')),
+        gvar, 1, 'GV28', 'Duplicate entry \'{}-{}\' for key \'PRIMARY\''.format(ut_id(gvar, 'gtg4'), ut_id(gvar, 'gty1.yaml')),
         '/group/metadata-add/', form_data={
             'group': ut_id(gvar, 'gtg4'),
-            'metadata_name': ut_id(gvar, 'gty1'),
+            'metadata_name': ut_id(gvar, 'gty1.yaml'),
             'enabled': 1,
             'mime_type': 'ucernvm-config',
             'metadata': '{"example": "not yaml"}',
@@ -159,10 +171,10 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty1')),
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty1.yaml')),
         '/group/metadata-add/', form_data={
             'group': ut_id(gvar, 'gtg5'),
-            'metadata_name': ut_id(gvar, 'gty1'),
+            'metadata_name': ut_id(gvar, 'gty1.yaml'),
             'enabled': 0,
             'mime_type': 'cloud-config',
             'metadata': '- example: yaml',
@@ -174,8 +186,29 @@ def main(gvar):
     execute_csv2_request(
         gvar, 0, None, None,
         '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
-        list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty1')},
-        values={'metadata_name': ut_id(gvar, 'gty1'), 'enabled': 0, 'metadata': '- example: yaml', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 1, 'mime_type': 'cloud-config'},
+        list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty1.yaml')},
+        values={'metadata_name': ut_id(gvar, 'gty1.yaml'), 'enabled': 0, 'metadata': '- example: yaml', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 1, 'mime_type': 'cloud-config'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty1.json')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg5'),
+            'metadata_name': ut_id(gvar, 'gty1.json'),
+            'enabled': 0,
+            'mime_type': 'cloud-config',
+            'metadata': '{"example":"json"}',
+            'priority': 1
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
+        list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty1.json')},
+        values={'metadata_name': ut_id(gvar, 'gty1.json'), 'enabled': 0, 'metadata': '{"example":"json"}', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 1, 'mime_type': 'cloud-config'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 

--- a/unit_tests/test_group_metadata_add.py
+++ b/unit_tests/test_group_metadata_add.py
@@ -98,7 +98,7 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: maybe this should be checked before insertion into db?
+    # TODO: better error message??
     execute_csv2_request(
         gvar, 1, 'GV28', 'Incorrect integer value: \'invalid-unit-test\' for column \'priority\' at row 1',
         '/group/metadata-add/', form_data={
@@ -112,12 +112,12 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: I thought files with .metadata endings were being validated as metadata
+    # TODO: I thought files with .yaml endings were being validated as yaml??
     # execute_csv2_request(
     #     gvar, 1, '???', '???',
     #     '/group/metadata-add/', form_data={
     #         'group': ut_id(gvar, 'gtg4'),
-    #         'metadata_name': 'invalid-unit-test.metadata',
+    #         'metadata_name': 'invalid-unit-test.yaml',
     #         'enabled': 0,
     #         'mime_type': 'cloud-config',
     #         'metadata': '{"invalid-unit-test":"yes"}',
@@ -169,6 +169,14 @@ def main(gvar):
             'metadata': '- example: yaml',
             'priority': 1
         },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
+        list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty1')},
+        values={'metadata_name': ut_id(gvar, 'gty1'), 'enabled': 0, 'metadata': '- example: yaml', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 1, 'mime_type': 'cloud-config'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 

--- a/unit_tests/test_group_metadata_add.py
+++ b/unit_tests/test_group_metadata_add.py
@@ -1,0 +1,176 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/metadata-add/',
+        server_user='invalid-unit-test', server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV29', 'invalid method "GET" specified.',
+        '/group/metadata-add/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/metadata-add/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/metadata-add/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu2'), server_pw='Abc123'
+    )
+    
+    execute_csv2_request(
+        gvar, 1, 'GV30', 'no group name specified.',
+        '/group/metadata-add/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV26', 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/metadata-add/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'group': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV26', 'cannot switch to invalid group "testing".',
+        '/group/metadata-add/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'group': 'testing'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV27', 'value specified for "metadata_name" must be all lower case.',
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': 'Invalid-Unit-Test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV27', 'boolean value specified for "enabled" must be one of the following: true, false, yes, no, 1, or 0.',
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': 'invalid-unit-test',
+            'enabled': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV27', 'value specified for "mime_type" must be one of the following options: [\'cloud-config\', \'ucernvm-config\'].',
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': 'invalid-unit-test',
+            'enabled': 0,
+            'mime_type': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV28', 'Field \'metadata\' doesn\'t have a default value',
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': 'invalid-unit-test',
+            'enabled': 0,
+            'mime_type': 'cloud-config'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    # TODO: maybe this should be checked before insertion into db?
+    execute_csv2_request(
+        gvar, 1, 'GV28', 'Incorrect integer value: \'invalid-unit-test\' for column \'priority\' at row 1',
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': 'invalid-unit-test',
+            'enabled': 0,
+            'mime_type': 'cloud-config',
+            'metadata': 'invalid-unit-test',
+            'priority': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    # TODO: I thought files with .metadata endings were being validated as metadata
+    # execute_csv2_request(
+    #     gvar, 1, '???', '???',
+    #     '/group/metadata-add/', form_data={
+    #         'group': ut_id(gvar, 'gtg4'),
+    #         'metadata_name': 'invalid-unit-test.metadata',
+    #         'enabled': 0,
+    #         'mime_type': 'cloud-config',
+    #         'metadata': '{"invalid-unit-test":"yes"}',
+    #         'priority': 1
+    #     },
+    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    # )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg4'), ut_id(gvar, 'gty1')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': ut_id(gvar, 'gty1'),
+            'enabled': 0,
+            'mime_type': 'cloud-config',
+            'metadata': '- example: metadata',
+            'priority': 1
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/list/',
+        list='group_list', filter={'group_name': ut_id(gvar, 'gtg4')},
+        values={'group_name': ut_id(gvar, 'gtg4'), 'metadata_names': ut_id(gvar, 'gty1')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV28', 'Duplicate entry \'{}-{}\' for key \'PRIMARY\''.format(ut_id(gvar, 'gtg4'), ut_id(gvar, 'gty1')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg4'),
+            'metadata_name': ut_id(gvar, 'gty1'),
+            'enabled': 1,
+            'mime_type': 'ucernvm-config',
+            'metadata': '{"example": "not yaml"}',
+            'priority': 0
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully added.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty1')),
+        '/group/metadata-add/', form_data={
+            'group': ut_id(gvar, 'gtg5'),
+            'metadata_name': ut_id(gvar, 'gty1'),
+            'enabled': 0,
+            'mime_type': 'cloud-config',
+            'metadata': '- example: yaml',
+            'priority': 1
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_metadata_delete.py
+++ b/unit_tests/test_group_metadata_delete.py
@@ -50,9 +50,8 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: 500
     execute_csv2_request(
-        gvar, 1, 'GV18', '???',
+        gvar, 1, 'GV18', 'cannot switch to invalid group "invalid-unit-test".',
         '/group/metadata-delete/', form_data={
             'metadata_name': 'invalid-unit-test',
             'group': 'invalid-unit-test'
@@ -60,9 +59,8 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: 500
     execute_csv2_request(
-        gvar, 1, 'GV18', '???',
+        gvar, 1, 'GV18', 'cannot switch to invalid group "testing".',
         '/group/metadata-delete/', form_data={
             'metadata_name': 'invalid-unit-test',
             'group': 'testing'

--- a/unit_tests/test_group_metadata_delete.py
+++ b/unit_tests/test_group_metadata_delete.py
@@ -1,0 +1,90 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/metadata-delete/',
+        server_user='invalid-unit-test', server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV34', 'invalid method "GET" specified.',
+        '/group/metadata-delete/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/metadata-delete/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    # TODO: should a privileged user be able to add metadata to a group they are not in?
+    # execute_csv2_request(
+    #     gvar, 1, '???', '???',
+    #     '/group/metadata-delete/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+    #     server_user=ut_id(gvar, 'gtu2'), server_pw='Abc123'
+    # )
+    
+    # TODO: should the error be "no metadata/meta name specified"?
+    execute_csv2_request(
+        gvar, 1, 'GV35', 'no group name specified.',
+        '/group/metadata-delete/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV32', 'request contained a bad parameter "invalid-unit-test".',
+        '/group/metadata-delete/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'invalid-unit-test': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/metadata-delete/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'group': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/metadata-delete/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'group': 'testing'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV33', '"{}::invalid-unit-test" failed - the request did not match any rows.'.format(ut_id(gvar, 'gtg5')),
+        '/group/metadata-delete/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'group': ut_id(gvar, 'gtg5')
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'file "{}::{}" successfully deleted.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5')),
+        '/group/metadata-delete/', form_data={
+            'metadata_name': ut_id(gvar, 'gty5'),
+            'group': ut_id(gvar, 'gtg5')
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_metadata_delete.py
+++ b/unit_tests/test_group_metadata_delete.py
@@ -80,9 +80,9 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 0, None, 'file "{}::{}" successfully deleted.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5')),
+        gvar, 0, None, 'file "{}::{}" successfully deleted.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty4')),
         '/group/metadata-delete/', form_data={
-            'metadata_name': ut_id(gvar, 'gty5'),
+            'metadata_name': ut_id(gvar, 'gty4'),
             'group': ut_id(gvar, 'gtg5')
         },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'

--- a/unit_tests/test_group_metadata_delete.py
+++ b/unit_tests/test_group_metadata_delete.py
@@ -27,7 +27,7 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
     )
 
-    # TODO: should a privileged user be able to add metadata to a group they are not in?
+    # TODO: should a privileged user be able to add/delete metadata to a group they are not in?
     # execute_csv2_request(
     #     gvar, 1, '???', '???',
     #     '/group/metadata-delete/', form_data={'invalid-unit-test': 'invalid-unit-test'},
@@ -50,8 +50,9 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
+    # TODO: 500
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV18', '???',
         '/group/metadata-delete/', form_data={
             'metadata_name': 'invalid-unit-test',
             'group': 'invalid-unit-test'
@@ -59,8 +60,9 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
+    # TODO: 500
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV18', '???',
         '/group/metadata-delete/', form_data={
             'metadata_name': 'invalid-unit-test',
             'group': 'testing'

--- a/unit_tests/test_group_metadata_delete.py
+++ b/unit_tests/test_group_metadata_delete.py
@@ -27,16 +27,8 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
     )
 
-    # TODO: should a privileged user be able to add/delete metadata to a group they are not in?
-    # execute_csv2_request(
-    #     gvar, 1, '???', '???',
-    #     '/group/metadata-delete/', form_data={'invalid-unit-test': 'invalid-unit-test'},
-    #     server_user=ut_id(gvar, 'gtu2'), server_pw='Abc123'
-    # )
-    
-    # TODO: should the error be "no metadata/meta name specified"?
     execute_csv2_request(
-        gvar, 1, 'GV35', 'no group name specified.',
+        gvar, 1, 'GV35', 'no metadata name specified.',
         '/group/metadata-delete/', form_data={'invalid-unit-test': 'invalid-unit-test'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )

--- a/unit_tests/test_group_metadata_fetch.py
+++ b/unit_tests/test_group_metadata_fetch.py
@@ -34,29 +34,22 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, None, 'received an invalid key "".',
-        '/group/metadata-fetch/',
+        gvar, 1, None, 'file "jodiew-gtg5::" does not exist.',
+        '/group/metadata-fetch/', form_data={'group': ut_id(gvar, 'gtg5')},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
     execute_csv2_request(
         gvar, 1, None, 'file "{}::invalid-unit-test" does not exist.'.format(ut_id(gvar, 'gtg5')),
-        '/group/metadata-fetch/{}::invalid-unit-test'.format(ut_id(gvar, 'gtg5')),
+        '/group/metadata-fetch/invalid-unit-test', form_data={'group': ut_id(gvar, 'gtg5')},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: how is this supposed to work?
-    # execute_csv2_request(
-    #     gvar, 0, None, None,
-    #     '/group/metadata-fetch/testing::another',
-    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    # )
-
-    # execute_csv2_request(
-    #     gvar, 0, None, None,
-    #     '/group/metadata-fetch/{}::{}'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5')),
-    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    # )
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/metadata-fetch/{}'.format(ut_id(gvar, 'gty5')), form_data={'group': ut_id(gvar, 'gtg5')},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
 
 if __name__ == "__main__":
     main(None)

--- a/unit_tests/test_group_metadata_fetch.py
+++ b/unit_tests/test_group_metadata_fetch.py
@@ -1,0 +1,62 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/metadata-fetch/',
+        server_user='invalid-unit-test', server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV36', 'user "{}" is not a member of any group.'.format(ut_id(gvar, 'gtu1')),
+        '/group/metadata-fetch/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV36', 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/metadata-fetch/', form_data={'group': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV36', 'cannot switch to invalid group "testing".',
+        '/group/metadata-fetch/', form_data={'group': 'testing'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'received an invalid key "".',
+        '/group/metadata-fetch/',
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'file "{}::invalid-unit-test" does not exist.'.format(ut_id(gvar, 'gtg5')),
+        '/group/metadata-fetch/{}::invalid-unit-test'.format(ut_id(gvar, 'gtg5')),
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    # TODO: how is this supposed to work?
+    # execute_csv2_request(
+    #     gvar, 0, None, None,
+    #     '/group/metadata-fetch/testing::another',
+    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    # )
+
+    # execute_csv2_request(
+    #     gvar, 0, None, None,
+    #     '/group/metadata-fetch/{}::{}'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5')),
+    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    # )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_metadata_list.py
+++ b/unit_tests/test_group_metadata_list.py
@@ -33,14 +33,5 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: figure out how this works
-    # execute_csv2_request(
-    #     gvar, 0, None, None,
-    #     '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
-    #     list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty5')},
-    #     values={'metadata_name': 'invalid'},
-    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    # )
-
 if __name__ == "__main__":
     main(None)

--- a/unit_tests/test_group_metadata_list.py
+++ b/unit_tests/test_group_metadata_list.py
@@ -1,0 +1,46 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/metadata-list/',
+        server_user='invalid-unit-test', server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'user "{}" is not a member of any group.'.format(ut_id(gvar, 'gtu1')),
+        '/group/metadata-list/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/metadata-list/', form_data={'group': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'cannot switch to invalid group "testing".',
+        '/group/metadata-list/', form_data={'group': 'testing'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    # TODO: figure out how this works
+    # execute_csv2_request(
+    #     gvar, 0, None, None,
+    #     '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
+    #     list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty5')},
+    #     values={'metadata_name': 'invalid'},
+    #     server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    # )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_metadata_update.py
+++ b/unit_tests/test_group_metadata_update.py
@@ -123,12 +123,12 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, '???', 'invalid yaml file',
+        gvar, 1, 'GV38', 'yaml value specified for "metadata (metadata_name)" is invalid - scanner error',
         '/group/metadata-update/', form_data={
             'metadata_name': ut_id(gvar, 'gty5.yaml'),
             'enabled': 0,
             'mime_type': 'ucernvm-config',
-            'metadata': '{"invalid-unit-test":"yes"}',
+            'metadata': 'foo: somebody said I should put a colon here: so I did',
             'priority': 10,
             'group': ut_id(gvar, 'gtg5')
         },

--- a/unit_tests/test_group_metadata_update.py
+++ b/unit_tests/test_group_metadata_update.py
@@ -35,7 +35,7 @@ def main(gvar):
 
     # TODO: this currently returns an SQL syntax error, should be something more user friendly
     execute_csv2_request(
-        gvar, 1, 'GV39', '???',
+        gvar, 1, 'GV39', 'group metadata-update "{}::invalid-unit-test" failed'.format(ut_id(gvar, 'gtg5')),
         '/group/metadata-update/', form_data={'metadata_name': 'invalid-unit-test'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
@@ -91,6 +91,35 @@ def main(gvar):
             'mime_type': 'cloud-config',
             'group': ut_id(gvar, 'gtg5')
         },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
+        list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty5')},
+        values={'metadata_name': ut_id(gvar, 'gty5'), 'enabled': 1, 'metadata': '- example: yaml', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 0, 'mime_type': 'cloud-config'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group metadata file "{}::{}" successfully  updated.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5')),
+        '/group/metadata-update/', form_data={
+            'metadata_name': ut_id(gvar, 'gty5'),
+            'enabled': 0,
+            'mime_type': 'ucernvm-config',
+            'metadata': '- example: metadata',
+            'priority': 10,
+            'group': ut_id(gvar, 'gtg5')
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
+        list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty5')},
+        values={'metadata_name': ut_id(gvar, 'gty5'), 'enabled': 0, 'metadata': '- example: metadata', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 10, 'mime_type': 'ucernvm-config'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 

--- a/unit_tests/test_group_metadata_update.py
+++ b/unit_tests/test_group_metadata_update.py
@@ -136,38 +136,12 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, '???', 'invalid json file',
-        '/group/metadata-update/', form_data={
-            'metadata_name': ut_id(gvar, 'gty5.json'),
-            'enabled': 0,
-            'mime_type': 'ucernvm-config',
-            'metadata': '- invalid-unit-test: yes',
-            'priority': 10,
-            'group': ut_id(gvar, 'gtg5')
-        },
-        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    )
-
-    execute_csv2_request(
         gvar, 0, None, 'group metadata file "{}::{}" successfully  updated.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5.yaml')),
         '/group/metadata-update/', form_data={
             'metadata_name': ut_id(gvar, 'gty5.yaml'),
             'enabled': 0,
             'mime_type': 'ucernvm-config',
             'metadata': '- example: valid-yaml',
-            'priority': 10,
-            'group': ut_id(gvar, 'gtg5')
-        },
-        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
-    )
-
-    execute_csv2_request(
-        gvar, 0, None, 'group metadata file "{}::{}" successfully  updated.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5.json')),
-        '/group/metadata-update/', form_data={
-            'metadata_name': ut_id(gvar, 'gty5.json'),
-            'enabled': 0,
-            'mime_type': 'ucernvm-config',
-            'metadata': '{"example":"valid-json"}',
             'priority': 10,
             'group': ut_id(gvar, 'gtg5')
         },

--- a/unit_tests/test_group_metadata_update.py
+++ b/unit_tests/test_group_metadata_update.py
@@ -28,7 +28,7 @@ def main(gvar):
     )
 
     execute_csv2_request(
-        gvar, 1, 'GV41', 'no group name specified.',
+        gvar, 1, 'GV41', 'no metadata name specified.',
         '/group/metadata-update/', form_data={'invalid-unit-test': 'invalid-unit-test'},
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
@@ -119,6 +119,58 @@ def main(gvar):
         '/group/metadata-list/', form_data={'group': ut_id(gvar, 'gtg5')},
         list='group_metadata_list', filter={'metadata_name': ut_id(gvar, 'gty5')},
         values={'metadata_name': ut_id(gvar, 'gty5'), 'enabled': 0, 'metadata': '- example: metadata', 'group_name': ut_id(gvar, 'gtg5'), 'priority': 10, 'mime_type': 'ucernvm-config'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', 'invalid yaml file',
+        '/group/metadata-update/', form_data={
+            'metadata_name': ut_id(gvar, 'gty5.yaml'),
+            'enabled': 0,
+            'mime_type': 'ucernvm-config',
+            'metadata': '{"invalid-unit-test":"yes"}',
+            'priority': 10,
+            'group': ut_id(gvar, 'gtg5')
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', 'invalid json file',
+        '/group/metadata-update/', form_data={
+            'metadata_name': ut_id(gvar, 'gty5.json'),
+            'enabled': 0,
+            'mime_type': 'ucernvm-config',
+            'metadata': '- invalid-unit-test: yes',
+            'priority': 10,
+            'group': ut_id(gvar, 'gtg5')
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group metadata file "{}::{}" successfully  updated.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5.yaml')),
+        '/group/metadata-update/', form_data={
+            'metadata_name': ut_id(gvar, 'gty5.yaml'),
+            'enabled': 0,
+            'mime_type': 'ucernvm-config',
+            'metadata': '- example: valid-yaml',
+            'priority': 10,
+            'group': ut_id(gvar, 'gtg5')
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group metadata file "{}::{}" successfully  updated.'.format(ut_id(gvar, 'gtg5'), ut_id(gvar, 'gty5.json')),
+        '/group/metadata-update/', form_data={
+            'metadata_name': ut_id(gvar, 'gty5.json'),
+            'enabled': 0,
+            'mime_type': 'ucernvm-config',
+            'metadata': '{"example":"valid-json"}',
+            'priority': 10,
+            'group': ut_id(gvar, 'gtg5')
+        },
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 

--- a/unit_tests/test_group_metadata_update.py
+++ b/unit_tests/test_group_metadata_update.py
@@ -33,7 +33,6 @@ def main(gvar):
         server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
     )
 
-    # TODO: this currently returns an SQL syntax error, should be something more user friendly
     execute_csv2_request(
         gvar, 1, 'GV39', 'group metadata-update "{}::invalid-unit-test" failed'.format(ut_id(gvar, 'gtg5')),
         '/group/metadata-update/', form_data={'metadata_name': 'invalid-unit-test'},

--- a/unit_tests/test_group_metadata_update.py
+++ b/unit_tests/test_group_metadata_update.py
@@ -1,0 +1,98 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+    
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/metadata-update/',
+        server_user='invalid-unit-test', server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV40', 'invalid method "GET" specified.',
+        '/group/metadata-update/',
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/metadata-update/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu1'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV41', 'no group name specified.',
+        '/group/metadata-update/', form_data={'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    # TODO: this currently returns an SQL syntax error, should be something more user friendly
+    execute_csv2_request(
+        gvar, 1, 'GV39', '???',
+        '/group/metadata-update/', form_data={'metadata_name': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV38', 'request contained a bad parameter "invalid-unit-test".',
+        '/group/metadata-update/', form_data={'metadata_name': 'invalid-unit-test', 'invalid-unit-test': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV37', 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/metadata-update/', form_data={'metadata_name': 'invalid-unit-test', 'group': 'invalid-unit-test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV37', 'cannot switch to invalid group "testing".',
+        '/group/metadata-update/', form_data={'metadata_name': 'invalid-unit-test', 'group': 'testing'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV38', 'value specified for "metadata_name" must be all lower case.',
+        '/group/metadata-update/', form_data={'metadata_name': 'Invalid-Unit-Test'},
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV38', 'boolean value specified for "enabled" must be one of the following: true, false, yes, no, 1, or 0.',
+        '/group/metadata-update/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'enabled': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV38', 'value specified for "mime_type" must be one of the following options: [\'cloud-config\', \'ucernvm-config\'].',
+        '/group/metadata-update/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'enabled': 0,
+            'mime_type': 'invalid-unit-test'
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV39', '"{}::invalid-unit-test" failed - the request did not match any rows.'.format(ut_id(gvar, 'gtg5')),
+        '/group/metadata-update/', form_data={
+            'metadata_name': 'invalid-unit-test',
+            'enabled': 0,
+            'mime_type': 'cloud-config',
+            'group': ut_id(gvar, 'gtg5')
+        },
+        server_user=ut_id(gvar, 'gtu3'), server_pw='Abc123'
+    )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_group_update.py
+++ b/unit_tests/test_group_update.py
@@ -63,7 +63,6 @@ def main(gvar):
         '/group/update/', form_data={'group_name': ut_id(gvar, 'gtg1-')}
     )
 
-    # TODO: better error message??
     execute_csv2_request(
         gvar, 1, 'GV24', 'group update "invalid-unit-test" failed',
         '/group/update/', form_data={'group_name': 'invalid-unit-test'}
@@ -74,9 +73,8 @@ def main(gvar):
         '/group/update/', form_data={'user_option': 'invalid-unit-test'}
     )
 
-    # TODO: 500
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV23', 'group update request did not contain mandatory parameter "group_name".',
         '/group/update/', form_data={'username': 'invalid-unit-test'}
     )
 
@@ -95,9 +93,8 @@ def main(gvar):
         values={'group_name': ut_id(gvar, 'gtg4'), 'condor_central_manager': 'unit-test-group-four-update.ca'}
     )
 
-    # TODO: 500
     execute_csv2_request(
-        gvar, 1, '???', '???',
+        gvar, 1, 'GV96', 'specified user "invalid-unit-test" does not exist.',
         '/group/update/', form_data={
             'group_name': ut_id(gvar, 'gtg4'),
             'username.1': 'invalid-unit-test'
@@ -111,7 +108,6 @@ def main(gvar):
         values={'group_name': ut_id(gvar, 'gtg4'), 'condor_central_manager': 'unit-test-group-four-update.ca'}
     )
 
-    # TODO: 500
     execute_csv2_request(
         gvar, 0, None, 'group "{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
         '/group/update/', form_data={

--- a/unit_tests/test_group_update.py
+++ b/unit_tests/test_group_update.py
@@ -63,8 +63,9 @@ def main(gvar):
         '/group/update/', form_data={'group_name': ut_id(gvar, 'gtg1-')}
     )
 
+    # TODO: better error message??
     execute_csv2_request(
-        gvar, 1, 'GV24', '???',
+        gvar, 1, 'GV24', 'group update "invalid-unit-test" failed',
         '/group/update/', form_data={'group_name': 'invalid-unit-test'}
     )
 
@@ -73,6 +74,7 @@ def main(gvar):
         '/group/update/', form_data={'user_option': 'invalid-unit-test'}
     )
 
+    # TODO: 500
     execute_csv2_request(
         gvar, 1, '???', '???',
         '/group/update/', form_data={'username': 'invalid-unit-test'}
@@ -93,6 +95,7 @@ def main(gvar):
         values={'group_name': ut_id(gvar, 'gtg4'), 'condor_central_manager': 'unit-test-group-four-update.ca'}
     )
 
+    # TODO: 500
     execute_csv2_request(
         gvar, 1, '???', '???',
         '/group/update/', form_data={
@@ -108,6 +111,7 @@ def main(gvar):
         values={'group_name': ut_id(gvar, 'gtg4'), 'condor_central_manager': 'unit-test-group-four-update.ca'}
     )
 
+    # TODO: 500
     execute_csv2_request(
         gvar, 0, None, 'group "{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
         '/group/update/', form_data={
@@ -129,11 +133,6 @@ def main(gvar):
         list='user_list', filter={'username': ut_id(gvar, 'gtu4')},
         values={'user_groups': ut_id(gvar, 'gtg4')}
     )
-    
-    # execute_csv2_request(
-    #     gvar, 1, '???', '???',
-    #     '/group/update/', form_data={}
-    # )
 
 if __name__ == "__main__":
     main(None)

--- a/unit_tests/test_group_update.py
+++ b/unit_tests/test_group_update.py
@@ -1,0 +1,139 @@
+from unit_test_common import execute_csv2_request, initialize_csv2_request, ut_id
+import sys
+
+def main(gvar):
+    if not gvar:
+        gvar = {}
+        if len(sys.argv) > 1:
+            initialize_csv2_request(gvar, sys.argv[0], selections=sys.argv[1])
+        else:
+            initialize_csv2_request(gvar, sys.argv[0])
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 401, unauthorized.',
+        '/group/update/',
+        server_user='invalid-unit-test', server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/update/',
+        server_user=ut_id(gvar, 'gtu1') , server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 2, None, 'HTTP response code 403, forbidden.',
+        '/group/update/',
+        server_user=ut_id(gvar, 'gtu3') , server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, None, 'user "{}" is not a member of any group.'.format(ut_id(gvar, 'gtu2')),
+        '/group/update/',
+        server_user=ut_id(gvar, 'gtu2') , server_pw='Abc123'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV25', 'invalid method "GET" specified.',
+        '/group/update/'
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV22', 'cannot switch to invalid group "invalid-unit-test".',
+        '/group/update/', form_data={'group': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV23', 'request contained a bad parameter "invalid-unit-test".',
+        '/group/update/', form_data={'invalid-unit-test': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV23', 'value specified for "group_name" must be all lower case, numeric digits, and dashes but cannot start or end with dashes.',
+        '/group/update/', form_data={'group_name': ut_id(gvar, 'Gtg1')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV23', 'value specified for "group_name" must be all lower case, numeric digits, and dashes but cannot start or end with dashes.',
+        '/group/update/', form_data={'group_name': ut_id(gvar, 'gtg!1')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV23', 'value specified for "group_name" must be all lower case, numeric digits, and dashes but cannot start or end with dashes.',
+        '/group/update/', form_data={'group_name': ut_id(gvar, 'gtg1-')}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV24', '???',
+        '/group/update/', form_data={'group_name': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, 'GV23', 'value specified for "user_option" must be one of the following options: [\'add\', \'delete\'].',
+        '/group/update/', form_data={'user_option': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/update/', form_data={'username': 'invalid-unit-test'}
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
+        '/group/update/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'condor_central_manager': 'unit-test-group-four-update.ca'
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/list/',
+        list='group_list', filter={'group_name': ut_id(gvar, 'gtg4')},
+        values={'group_name': ut_id(gvar, 'gtg4'), 'condor_central_manager': 'unit-test-group-four-update.ca'}
+    )
+
+    execute_csv2_request(
+        gvar, 1, '???', '???',
+        '/group/update/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'username.1': 'invalid-unit-test'
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/list/',
+        list='group_list', filter={'group_name': ut_id(gvar, 'gtg4')},
+        values={'group_name': ut_id(gvar, 'gtg4'), 'condor_central_manager': 'unit-test-group-four-update.ca'}
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, 'group "{}" successfully updated.'.format(ut_id(gvar, 'gtg4')),
+        '/group/update/', form_data={
+            'group_name': ut_id(gvar, 'gtg4'),
+            'username.1': ut_id(gvar, 'gtu4')
+        }
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/group/list/',
+        list='group_list', filter={'group_name': ut_id(gvar, 'gtg4')},
+        values={'group_name': ut_id(gvar, 'gtg4'), 'condor_central_manager': 'unit-test-group-four-update.ca'}
+    )
+
+    execute_csv2_request(
+        gvar, 0, None, None,
+        '/user/list/',
+        list='user_list', filter={'username': ut_id(gvar, 'gtu4')},
+        values={'user_groups': ut_id(gvar, 'gtg4')}
+    )
+    
+    # execute_csv2_request(
+    #     gvar, 1, '???', '???',
+    #     '/group/update/', form_data={}
+    # )
+
+if __name__ == "__main__":
+    main(None)

--- a/unit_tests/test_user0_add.py
+++ b/unit_tests/test_user0_add.py
@@ -144,6 +144,11 @@ def main(gvar):
         gvar, 1, 'UV06', 'user group-add "{0}.[\'{1}\', \'{1}\']" failed - (1062, "Duplicate entry \'{0}-{1}\' for key \'PRIMARY\'").'.format(ut_id(gvar, 'utu6'), ut_id(gvar, 'utg3')),
         '/user/add/', form_data={'username': ut_id(gvar, 'utu6'), 'password1': 'AaBbCc123', 'password2': 'AaBbCc123', 'cert_cn': '%s test user six' % ut_id(gvar, 'unit'), 'is_superuser': True, 'group_name.2': ut_id(gvar, 'utg3'), 'group_name.1': ut_id(gvar, 'utg3')}
         )
+    
+    execute_csv2_request(
+        gvar, 1, 'UV01', 'request did not contain mandatory parameter "username".',
+        '/user/add/', form_data={'password1': 'AaBbCc123', 'password2': 'AaBbCc123'}
+        )
 
 if __name__ == "__main__":
     main(None)

--- a/unit_tests/test_user0_add.py
+++ b/unit_tests/test_user0_add.py
@@ -145,11 +145,5 @@ def main(gvar):
         '/user/add/', form_data={'username': ut_id(gvar, 'utu6'), 'password1': 'AaBbCc123', 'password2': 'AaBbCc123', 'cert_cn': '%s test user six' % ut_id(gvar, 'unit'), 'is_superuser': True, 'group_name.2': ut_id(gvar, 'utg3'), 'group_name.1': ut_id(gvar, 'utg3')}
         )
 
-    execute_csv2_request(
-        gvar, 0, None, None,
-        '/user/list/',
-        list='user_list', filter={'username': ut_id(gvar, 'utu6')}, values={'cert_cn': '%s test user six' % ut_id(gvar, 'unit'), 'user_groups': ut_id(gvar, 'utg3'), 'is_superuser': 1}
-        )
-
 if __name__ == "__main__":
     main(None)

--- a/unit_tests/unit_test_common.py
+++ b/unit_tests/unit_test_common.py
@@ -113,17 +113,41 @@ def execute_csv2_request(gvar, expected_rc, expected_ec, expected_text, request,
 
             return 1
         else:
+            if list and filter and values and (list not in response):
+                failed = True
+                if not gvar['hidden']:
+                    print('\n%03d %s Failed: %s, %s, %s, %s' % (gvar['ut_count'], _caller(), request, list, filter, values))
+                    print('\tNo list "{}" in response.\n'.format(list))
             if list and filter and values and list in response:
                 failed = False
-                for row in response[list]:
+                if len(response[list]) > 0:
+                    # Will only work for a single value in filter!!
                     for key in filter:
-                        if row[key] == filter[key]:
+                        filtered_list = [row for row in response[list] if key in row.keys() and row[key] == filter[key]]
+                    if len(filtered_list) > 0:
+                        for row in filtered_list:
                             for key in values:
-                                if row[key] != values[key]:
+                                if key not in row.keys():
                                     failed = True
                                     if not gvar['hidden']:
                                         print('\n%03d %s Failed: %s, %s, %s, %s' % (gvar['ut_count'], _caller(), request, list, filter, values))
-                                        print('    row=%s\n' % row)
+                                        print('\trow=%s' % row)
+                                        print('\tValue key "{}" not present in row.\n'.format(key))
+                                elif row[key] != values[key]:
+                                    failed = True
+                                    if not gvar['hidden']:
+                                        print('\n%03d %s Failed: %s, %s, %s, %s' % (gvar['ut_count'], _caller(), request, list, filter, values))
+                                        print('\trow=%s\n' % row)
+                    else:
+                        failed = True
+                        if not gvar['hidden']:
+                            print('\n%03d %s Failed: %s, %s, %s, %s' % (gvar['ut_count'], _caller(), request, list, filter, values))
+                            print('\tFilter didn\'t match any rows\n')
+                else:
+                    failed = True
+                    if not gvar['hidden']:
+                        print('\n%03d %s Failed: %s, %s, %s, %s' % (gvar['ut_count'], _caller(), request, list, filter, values))
+                        print('\tResponse list "{}" is empty.\n'.format(list))
 
                 if failed:
                     gvar['ut_failed'] += 1

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -245,8 +245,13 @@ def delete(request):
                 'cloud_flavors'
             ], active_user)
         if rc != 0:        
+<<<<<<< 1dafe26649e9f1d1116c8f07c091cbb1c97c2dcb
             db_close(db_ctl)
             return list(request, selector='-', response_code=1, message='%s group delete %s' % (lno('CV09'), msg), active_user=active_user, user_groups=user_groups)
+=======
+            db_connection.close()
+            return list(request, selector='-', response_code=1, message='%s group delete %s' % (lno('GV09'), msg), active_user=active_user, user_groups=user_groups)
+>>>>>>> Fix typo 'CV09' -> 'GV09'
 
         # Delete any group metadata files for the group.
         s = select([view_groups_with_metadata_names]).where((view_groups_with_metadata_names.c.group_name == fields['group_name']))

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -518,7 +518,7 @@ def metadata_add(request):
         if request.method != 'POST':
             return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_add, invalid method "%s" specified.' % (lno('GV29'), request.method)})
         else:
-            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_add, no group name specified.' % lno('GV30')})
+            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_add, no metadata name specified.' % lno('GV30')})
 
 #-------------------------------------------------------------------------------
 
@@ -568,7 +568,7 @@ def metadata_delete(request):
         if request.method != 'POST':
             return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_delete, invalid method "%s" specified.' % (lno('GV34'), request.method)})
         else:
-            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_delete, no group name specified.' % lno('GV35')})
+            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_delete, no metadata name specified.' % lno('GV35')})
 
 #-------------------------------------------------------------------------------
 
@@ -693,7 +693,7 @@ def metadata_update(request):
         if request.method != 'POST':
             return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_update, invalid method "%s" specified.' % (lno('GV40'), request.method)})
         else:
-            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_update, no group name specified.' % lno('GV41')})
+            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata_update, no metadata name specified.' % lno('GV41')})
 
 #-------------------------------------------------------------------------------
 

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -245,13 +245,8 @@ def delete(request):
                 'cloud_flavors'
             ], active_user)
         if rc != 0:        
-<<<<<<< 1dafe26649e9f1d1116c8f07c091cbb1c97c2dcb
-            db_close(db_ctl)
-            return list(request, selector='-', response_code=1, message='%s group delete %s' % (lno('CV09'), msg), active_user=active_user, user_groups=user_groups)
-=======
             db_connection.close()
             return list(request, selector='-', response_code=1, message='%s group delete %s' % (lno('GV09'), msg), active_user=active_user, user_groups=user_groups)
->>>>>>> Fix typo 'CV09' -> 'GV09'
 
         # Delete any group metadata files for the group.
         s = select([view_groups_with_metadata_names]).where((view_groups_with_metadata_names.c.group_name == fields['group_name']))
@@ -550,7 +545,7 @@ def metadata_delete(request):
         rc, msg, fields, tables, columns = validate_fields(request, [METADATA_KEYS], db_ctl, ['csv2_group_metadata'], active_user)
         if rc != 0:        
             db_close(db_ctl)
-            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata-add %s' % (lno('CV32'), msg)})
+            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata-add %s' % (lno('GV32'), msg)})
 
         # Delete the group metadata file.
         table = tables['csv2_group_metadata']
@@ -678,7 +673,7 @@ def metadata_update(request):
         rc, msg, fields, tables, columns = validate_fields(request, [METADATA_KEYS], db_ctl, ['csv2_group_metadata'], active_user)
         if rc != 0:        
             db_close(db_ctl)
-            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata-add %s' % (lno('CV38'), msg)})
+            return render(request, 'csv2/groups.html', {'response_code': 1, 'message': '%s group metadata-add %s' % (lno('GV38'), msg)})
 
         # Update the group metadata file.
         table = tables['csv2_group_metadata']

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -245,7 +245,7 @@ def delete(request):
                 'cloud_flavors'
             ], active_user)
         if rc != 0:        
-            db_connection.close()
+            db_close(db_ctl)
             return list(request, selector='-', response_code=1, message='%s group delete %s' % (lno('GV09'), msg), active_user=active_user, user_groups=user_groups)
 
         # Delete any group metadata files for the group.


### PR DESCRIPTION
Tests for all `/group/` endpoints added. `./run_tests` changed to easily handle new objects and tests.