### PR TITLE
Make service_enable_condor_poller match all python 3.x versions

### DIFF
--- a/utilities/service_enable_condor_poller
+++ b/utilities/service_enable_condor_poller
@@ -110,7 +110,7 @@ EOF
     headercheck=1
     #if [ $tv2 -eq 4 ]; then ls  /usr/include/python3.4m/Python.h &>/dev/null; headercheck=$?; fi
     #if [ $tv2 -eq 6 ]; then ls  /usr/include/python3.6m/Python.h &>/dev/null; headercheck=$?; fi
-    ls  /usr/include/python3.?m/Python.h &>/dev/null; headercheck=$?
+    ls  /usr/include/python3.*/Python.h &>/dev/null; headercheck=$?
     if [ $headercheck -ne 0 ]; then
        echo 'ERROR: You need to install python3 devel before we can proceed.'
        exit 1


### PR DESCRIPTION
The current version doesn't match non m versions of python and won't match python version > 3.10