### PR TITLE
Prevent condor poller access for localhost

### DIFF
--- a/data_collectors/condor/condor_poller.py
+++ b/data_collectors/condor/condor_poller.py
@@ -1500,7 +1500,12 @@ if __name__ == '__main__':
     config = procMon.get_config()
     logging = procMon.get_logging()
     version = config.get_version()
+    is_hostname_localhost = config.is_hostname_localhost()
 
+    if is_hostname_localhost:
+        logging.error("Hostname can not be localhost, exiting...")
+        exit(1)
+    
     PID_FILE = config.categories["ProcessMonitor"]["pid_path"] + os.path.basename(sys.argv[0])
     with open(PID_FILE, "w") as fd:
         fd.write(str(os.getpid()))

--- a/lib/db_config.py
+++ b/lib/db_config.py
@@ -70,10 +70,6 @@ class Config:
             return
 
         self.db_schema = schema_na.schema
-        
-        if socket.gethostbyname(socket.gethostname()) == socket.gethostname():
-            logging.error("hostname cannot be localhost ip")
-            exit(1)
 
         #
         # Use the integer value of the public IPv4 address to create a unique instance IDs for the
@@ -592,6 +588,12 @@ class Config:
 
     def get_version(self):
         return self.version
+
+
+#-------------------------------------------------------------------------------
+
+    def is_hostname_localhost(self):
+        return socket.gethostname() == '127.0.0.1'
 
 
 #-------------------------------------------------------------------------------

--- a/lib/db_config.py
+++ b/lib/db_config.py
@@ -70,6 +70,10 @@ class Config:
             return
 
         self.db_schema = schema_na.schema
+        
+        if socket.gethostbyname(socket.gethostname()) == socket.gethostname():
+            logging.error("hostname cannot be localhost ip")
+            exit(1)
 
         #
         # Use the integer value of the public IPv4 address to create a unique instance IDs for the


### PR DESCRIPTION
Add error message and exit for condor poller when hostname is set to localhost ip. 