### PR TITLE
Fix refresh timer

### DIFF
--- a/web_frontend/cloudscheduler/csv2/static/csv2/status.js
+++ b/web_frontend/cloudscheduler/csv2/static/csv2/status.js
@@ -162,7 +162,7 @@ function set_refresh(time) {
 
         fetch(location.href,{   
             method: 'GET',
-            headers: {'Accept': 'application/json', 'Content-Type':'application/json'},
+            headers: {'Accept': 'text/html', 'Content-Type':'application/json'},
         })  
         .then(function(response){
             /* Check response status code*/


### PR DESCRIPTION
Fixes the issue the page not refreshing every 30 seconds. The format of the returned data from fetching did not contain the keys it was looking for, causing an error on each refresh. 