### PR TITLE
fix placement of days left

### DIFF
--- a/web_frontend/cloudscheduler/csv2/templates/csv2/status.html
+++ b/web_frontend/cloudscheduler/csv2/templates/csv2/status.html
@@ -312,6 +312,9 @@
                             <!-- Jobs expand row to show cores-->
                             <tr class="extra-row" id="expand-jobs-{{group.group_name}}{% if jobs_by_target_alias_flag %}-{{group.target_alias}}{% endif %}">
                                 <td onclick="toggle_id('expand-jobs-{{group.group_name}}{% if jobs_by_target_alias_flag %}-{{group.target_alias}}{% endif %}')"></td>
+                                {% if jobs_by_target_alias_flag %}
+                                    <td></td>
+                                {% endif %}
                                 <td></td>
                                 <td colspan="5">
                                     <table class="job-extra-row">
@@ -371,7 +374,6 @@
 
                                 <td class="col-spacer">&nbsp;</td>
 
-                                <td></td>
                                 <td></td>
                                 <td></td>
                                 <td data-path="{{group.group_name}} jobs_condor_days_left" class="zero-style float-center">


### PR DESCRIPTION
The days left columns for the condor and condor worker certs were not aligned to their respective headers. This seems to have been an issue with having an extra column added for fixing the alignment when there is a target alias. Fixed by adding an extra row if there is a target alias column and removing the extra spacer at the end.