### PR TITLE
condor_poller: address python syntax warning ("is not" used with literal)

### DIFF
--- a/data_collectors/condor/condor_poller.py
+++ b/data_collectors/condor/condor_poller.py
@@ -183,7 +183,7 @@ def get_gsi_cert_subject_and_eol(cert):
 
 def get_master_classad(session, machine, hostname):
     try:
-        if machine is not "":
+        if machine != "":
             condor_classad = session.query(MASTER_TYPE, 'Name=="%s"' % machine)[0]
         else:
             condor_classad = session.query(MASTER_TYPE, 'regexp("%s", Name, "i")' % hostname)[0]


### PR DESCRIPTION
Python 3.8 introduced a new syntax warning when "is not" or "is" was used with a literal.  "is" and "is not" test for identity (that the two objects are the exact same object) while "==" and "!=" test for equality (two objects have the same value).

The use of "is" and "is not" often work by accident because some implementations of python (CPython for example) re-use literal objects where possible to improve performance.  This means that a literal used to initialise a variable could end up being the same object utilised in a subsequent "is" or "is not" conditional expression.  However, if re-use is not possible at the time (or something other than CPython is in use) then the use of "is" and "is not" will probably not produce the desired outcome. This was the reason the warning was introduced.

Considering the context in which the construct is used, it seems that an inequality test was intended.