### PR TITLE
condor_poller: don't assume condor_worker_cert is defined.

### DIFF
--- a/data_collectors/condor/condor_poller.py
+++ b/data_collectors/condor/condor_poller.py
@@ -1220,7 +1220,7 @@ def worker_gsi_poller():
 
 
             #if 'GSI_DAEMON_CERT' in htcondor.param or config.condor_poller["token_auth"]:
-            if config.condor_poller['condor_worker_cert'] is not None and config.condor_poller['condor_worker_cert'] != "":
+            if 'condor_worker_cert' in config.condor_poller and config.condor_poller['condor_worker_cert'] is not None and config.condor_poller['condor_worker_cert'] != "":
                 try:
                     worker_cert['subject'], worker_cert['eol'] = get_gsi_cert_subject_and_eol(config.condor_poller['condor_worker_cert'])
                     worker_cert['cert'] = zip_base64(config.condor_poller['condor_worker_cert'])


### PR DESCRIPTION
If condor_worker_cert is not set in the configuration file, the respective key won't be present in config.condor_poller.  This will cause the conditional in worker_gsi_poller() to fail because the existing expression assumes that the key exists in some form.

When there is no worker certificate (as is the case if tokens are being used), this issue can be worked around by setting condor_worker_cert to the empty string in the configuration file.  However, this triggers collateral error messages because the code assumes that if defined, condor_worker_cert is a valid filename.  Addressing the underlying problem is therefore worthwhile.