### PR TITLE
Fix the service_enable_condor_poller script for alma9

### DIFF
--- a/utilities/service_enable_condor_poller
+++ b/utilities/service_enable_condor_poller
@@ -14,34 +14,83 @@
 ### 10. Checks/installs prerequisite pip modules.
 ### 11. Installs, enables, and starts csv2-condor-poller initd/systemd service.
 ###
+parse_version () {
+	#takes a package version string and returns a string of numbers
+	# "epoch v1 v2 v3 v4 ... " with any non-numeric versions discarded
+
+	#split into [epoch, everything else]
+	ver=(${1//!/ })
+	#if the array is length 1, set epoch to 0
+	if [ ${#ver[@]} -eq 1 ]; then
+		tempvar="0.$1"
+		ver=(${tempvar//./ })
+	else
+		epoch=${ver[0]}
+		tempvar="$epoch.${ver[1]}"
+		ver=(${tempvar//./ })
+	fi
+	# find first non-numeric element
+	index=0
+	for i in ${ver[@]}; do
+		if [[ $i =~ ^[0-9]+$ ]]; then
+			index=$(($index + 1))
+		else
+			break
+		fi
+	done
+	# delete non-numeric entries
+	length=${#ver[@]}
+	for ((i=$index;i<length;i++)); do
+		unset ver[$i]
+	done
+
+	#return string
+	echo "${ver[@]}"
+}
+
+is_a_newer_than_b () {
+	# compares if package a is newer than package b
+	# $1 = package a version string
+	# $2 = package b version string
+
+	newer=false
+	# get the version arrays
+	astr=$(parse_version $1)
+	A=(${astr// / })
+
+	bstr=$(parse_version $2)
+	B=(${bstr// / })
+	# get min length
+	min=${#A[@]}
+	if [ $min -gt ${#B[@]} ]; then
+		min=${#B[@]}
+	fi
+
+	#compare each number in min length until a difference is found
+	for ((i=0;i<$min;i++)); do
+		if [ ${A[$i]} -gt ${B[$i]} ]; then
+			newer=true
+			break
+		fi
+	done
+
+	echo $newer
+}
 check_sw () {
     # $1 - package
     # $2 - tested version
 
-    IFS=. read tv1 tv2 tv3 <<EOF
-$2
-EOF
-    TV=$(( ( ( ( $tv1 * 1000 ) + $tv2 ) * 1000 ) + $tv3 ))
-
+    TV=$2
     version=$(python3 -m pip show $1 | awk '/^Version/ {print $2}')
-    IFS=. read av1 av2 av3 <<EOF
-$version
-EOF
-
-    if [ "$av3" == "" ]; then
-        av3='0'
-    fi
-
+    AV=$version
     if [ "$version" == "" ]; then
         echo "Installing python package '$1', version '$2'."
         python3 -m pip install "$1==$2"
     else
-        AV=$(( ( ( ( $av1 * 1000 ) + $av2 ) * 1000 ) + $av3 ))
-
-        if [ $AV -gt $TV ]; then
+        if $(is_a_newer_than_b $AV $TV); then
            echo "Warning: The python package '$1', version '$version' is installed.  This is a later version than tested ($2)."
 
-        elif [ $AV -lt $TV ]; then
+        elif $(is_a_newer_than_b $TV $AV); then
             echo "The python package '$1' version '$version' is installed, updating package to tested vesion '$2'."
             python3 -m pip install "$1==$2" --upgrade 
         fi

--- a/utilities/service_enable_condor_poller
+++ b/utilities/service_enable_condor_poller
@@ -74,6 +74,10 @@ is_a_newer_than_b () {
 			break
 		fi
 	done
+	# if the first $min entries in A and B are equal and A is longer, A is newer
+	if [ "$(printf "%s " "${A[@]:0:$min}")" == "$(printf "%s " "${B[@]:0:$min}")" ] && [ ${#A[@]} -gt $min ];then
+		newer=true
+	fi
 
 	echo $newer
 }

--- a/utilities/service_enable_condor_poller
+++ b/utilities/service_enable_condor_poller
@@ -6,13 +6,14 @@
 ### 2.  Checks to see if we are running as root.
 ### 3.  Checks to see if we are installed correctly in /opt.
 ### 4.  Checks to see if python3 and header files are installed.
-### 5.  Create the cloudscheduler user and group.
-### 6.  Add the condor user to the cloudscheduler group.
-### 7.  Create the cloudscheduler run directory
-### 8.  Create the cloudscheduler logging directory.
-### 9.  Creates a python3 virtual environment.
-### 10. Checks/installs prerequisite pip modules.
-### 11. Installs, enables, and starts csv2-condor-poller initd/systemd service.
+### 5.  Checks to see if gcc is installed
+### 6.  Create the cloudscheduler user and group.
+### 7.  Add the condor user to the cloudscheduler group.
+### 8.  Create the cloudscheduler run directory
+### 9.  Create the cloudscheduler logging directory.
+### 10.  Creates a python3 virtual environment.
+### 11. Checks/installs prerequisite pip modules.
+### 12. Installs, enables, and starts csv2-condor-poller initd/systemd service.
 ###
 parse_version () {
 	#takes a package version string and returns a string of numbers
@@ -155,7 +156,17 @@ EOF
     fi
 
 ###
-### 5.  Create the cloudscheduler user and group.
+### 5.  Checks to see if gcc is installed (this is required to install some python packages)
+###
+    gcc_ver=$(gcc --version 2>/dev/null)
+    returncode=$?
+    if [ $returncode -ne 0 ]; then
+        echo 'ERROR: You need to install gcc before we can proceed.'
+        exit 1
+    fi
+
+###
+### 6.  Create the cloudscheduler user and group.
 ###
     id cloudscheduler >/dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -163,12 +174,12 @@ EOF
     fi
 
 ###
-### 6.  Add the condor user to the cloudscheduler group.
+### 7.  Add the condor user to the cloudscheduler group.
 ###
     usermod -a -G cloudscheduler condor
 
 ###
-### 7.  Create the cloudscheduler run directory
+### 8.  Create the cloudscheduler run directory
 ###
     mkdir -p /var/local/cloudscheduler/run
     chown cloudscheduler.cloudscheduler /var/local/cloudscheduler
@@ -177,14 +188,14 @@ EOF
     chmod 0775 /var/local/cloudscheduler/run
 
 ###
-### 8.  Create the cloudscheduler log directory.
+### 9.  Create the cloudscheduler log directory.
 ###
     mkdir -p /var/log/cloudscheduler
     chown cloudscheduler.cloudscheduler /var/log/cloudscheduler
     chmod 0775 /var/log/cloudscheduler
 
 ###
-### 9.  Creates a python3 virtual environment.
+### 10.  Creates a python3 virtual environment.
 ###
     stat /opt/cloudscheduler/python3 >/dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -207,7 +218,7 @@ EOF
 
 
 ###
-### 10. Checks/installs prerequisite pip modules.
+### 11. Checks/installs prerequisite pip modules.
 ###
     check_sw boto3 1.9.130
     #figure out a good version for htcondor depending on the installed condor server version
@@ -220,7 +231,7 @@ EOF
     check_sw python-novaclient 10.3.0
 
 ###
-### 11. Installs, enables, and starts csv2-condor-poller initd/systemd service.
+### 12. Installs, enables, and starts csv2-condor-poller initd/systemd service.
 ###
     if [ $systemctl -eq 1 ]; then
         cp /opt/cloudscheduler/etc/init.d/csv2-condor-poller.pfile /etc/init.d/csv2-condor-poller


### PR DESCRIPTION
Fixes an issue where the install would sometimes fail if there are installed python packages with versions not following an n(.n)* scheme. Now better handles the python package version scheme specified in [https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers). 

Also adds a warning that gcc needs to be installed before installation can continue due to psutil requiring it. 

There is still an issue where git is never required but this does not effect the install. 