### PR TITLE
Fix views using ace code editor on alma9

### DIFF
--- a/web_frontend/cloudscheduler/cloudscheduler_web/settings.py.j2
+++ b/web_frontend/cloudscheduler/cloudscheduler_web/settings.py.j2
@@ -234,3 +234,4 @@ CELERY_ROUTES = {
     'Glintv2.glintv2.tasks.tx_request': {'queue': 'tx_requests'},
 }
 
+X_FRAME_OPTIONS = 'SAMEORIGIN'

--- a/web_frontend/cloudscheduler/csv2/static/csv2/editor.css
+++ b/web_frontend/cloudscheduler/csv2/static/csv2/editor.css
@@ -8,7 +8,7 @@
 }
 
 .editor-footer {
-  position: absolute;
+  position: relative;
   right: 0;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
Issue #433 

Set x-frame setting to allow rendering iframes from the same origin (default is DENY). 

Changed position of the error message box for the editor as previously it could block the add, update, and delete buttons at certain large scalings and small resolutions. 