### PR TITLE
Fix Behaviour When Deleting the Active Group

### DIFF
--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -1007,14 +1007,14 @@ def set_user_groups(config, request, super_user=True):
 #       return 1,'user "%s" is not a member of any group.' % new_active_user.username, new_active_user, new_active_user.user_groups
         return 1,'user "%s" is not a member of any group.' % new_active_user.username, new_active_user
 
-    if len(new_active_user.args) > 0 and new_active_user.args[0] in new_active_user.user_groups:
+    if len(new_active_user.args) > 0:
         new_active_user.active_group = new_active_user.args[0]
     elif new_active_user.default_group and new_active_user.default_group in new_active_user.user_groups:
         new_active_user.active_group = new_active_user.default_group
     else:
         new_active_user.active_group = new_active_user.user_groups[0]
     if new_active_user.active_group not in new_active_user.user_groups and new_active_user.active_group != 'ALL':
-#       return 1,'cannot switch to invalid group "%s".' % new_active_user.active_group, new_active_user, new_active_user.user_groups
+        # new_active_user.active_group = new_active_user.user_groups[0]
         return 1,'cannot switch to invalid group "%s".' % new_active_user.active_group, new_active_user
 
 #   return 0, None, new_active_user, new_active_user.user_groups

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -1014,7 +1014,6 @@ def set_user_groups(config, request, super_user=True):
     else:
         new_active_user.active_group = new_active_user.user_groups[0]
     if new_active_user.active_group not in new_active_user.user_groups and new_active_user.active_group != 'ALL':
-        # new_active_user.active_group = new_active_user.user_groups[0]
         return 1,'cannot switch to invalid group "%s".' % new_active_user.active_group, new_active_user
 
 #   return 0, None, new_active_user, new_active_user.user_groups

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -663,38 +663,15 @@ def delete(request):
             config.db_close()
             return group_list(request, active_user=active_user, response_code=1, message='%s group flavors delete "%s" failed - %s.' % (lno(MODID), fields['group_name'], msg))
 
-        # Delete the group from the user
-        # rc, msg = manage_user_groups(config, None, active_user.username, active_user.user_groups.remove(fields['group_name']), option='delete')
-        # if rc != 0:
-        #     config.close()
-        #     return group_list(request, active_user=active_user, response_code=1, message=f"{lno(MODID)} Failed to remove group {fields['group_name']} from user {active_user.username}, {msg}")
-        # if group being deleted is active_user.active_group
-        # we should switch away from the group
+        # if group being deleted is active_user.active_group switch away from the group
         if fields['group_name'] == active_user.active_group:
-            logger = logging.getLogger()
-            logger.setLevel(logging.INFO)
-            file_handler = logging.FileHandler('/opt/cloudscheduler/log.log')
-            file_handler.setLevel(logging.DEBUG)
-            logger.addHandler(file_handler)
-            logging.info(f"{fields['group_name']} being deleted is same as user's current active group:{active_user.active_group}") 
-            logging.info(f"fields: {fields}")
-            logging.info(f"active_user:{active_user}")
-            logging.info(f"active_group:{active_user.active_group}, \nuser_groups:{active_user.user_groups}, \navailable_groups:{active_user.available_groups}, \ndefault: {active_user.default_group}")
-            try:
-                # determine a suitable group to switch to
-                    # switch to default group if it is present and not being deleted
-                if active_user.default_group != None and active_user.default_group != active_user.active_group:
-                    logging.info(f"switching to default group: {active_user.default_group}")
-                    active_user.active_group = active_user.default_group
-                # switch to the first valid group in user_groups if there are any
-                elif len(active_user.user_groups) > 0:
-                    active_user.active_group = active_user.user_groups[0]
-                # there are no groups for this user, set the active group to the
-                # default constructor value
-                else:
-                    active_user.active_group = '-'
-            except Exception as err:
-                logging.info(f"error: {err}")
+            if active_user.default_group != None and active_user.default_group != active_user.active_group:
+                active_user.active_group = active_user.default_group
+            elif len(active_user.user_groups) > 0:
+                active_user.active_group = active_user.user_groups[0]
+            else:
+                active_user.active_group = '-'
+        
         # Delete the group.
         table = 'csv2_groups'
         rc, msg = config.db_delete(table, where=where_clause)

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -18,8 +18,8 @@ from cloudscheduler.lib.view_utils import \
     table_fields, \
     validate_by_filtered_table_entries, \
     validate_fields, \
-    get_file_checksum, \
-    manage_user_groups
+    get_file_checksum
+
 from collections import defaultdict
 import bcrypt
 
@@ -29,8 +29,6 @@ import re
 from cloudscheduler.lib.web_profiler import silk_profile as silkp
 
 from csv2.gen_public_page import generate_static_page
-
-import logging
 
 # lno: GV - error code identifier.
 MODID= 'GV'
@@ -305,8 +303,7 @@ def add(request):
     ### Bad request.
     else:
         config.db_close()
-        message = '%s group add, invalid method "%s" specified.' % (lno(MODID), request.method) ###
-        # message = f"group add failed at {lno(MODID)}, invalid method {request.method} specified. Full request: {request.__dict__}"
+        message = '%s group add, invalid method "%s" specified.' % (lno(MODID), request.method)
         request.session["response"] = {"message": message, "response_code": 1, "group": group}
         return redirect("/group/list/")
         #return group_list(request, active_user=active_user, response_code=1, message='%s group add, invalid method "%s" specified.' % (lno(MODID), request.method))

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -18,7 +18,8 @@ from cloudscheduler.lib.view_utils import \
     table_fields, \
     validate_by_filtered_table_entries, \
     validate_fields, \
-    get_file_checksum
+    get_file_checksum, \
+    manage_user_groups
 from collections import defaultdict
 import bcrypt
 
@@ -28,6 +29,8 @@ import re
 from cloudscheduler.lib.web_profiler import silk_profile as silkp
 
 from csv2.gen_public_page import generate_static_page
+
+import logging
 
 # lno: GV - error code identifier.
 MODID= 'GV'
@@ -302,7 +305,8 @@ def add(request):
     ### Bad request.
     else:
         config.db_close()
-        message = '%s group add, invalid method "%s" specified.' % (lno(MODID), request.method)
+        message = '%s group add, invalid method "%s" specified.' % (lno(MODID), request.method) ###
+        # message = f"group add failed at {lno(MODID)}, invalid method {request.method} specified. Full request: {request.__dict__}"
         request.session["response"] = {"message": message, "response_code": 1, "group": group}
         return redirect("/group/list/")
         #return group_list(request, active_user=active_user, response_code=1, message='%s group add, invalid method "%s" specified.' % (lno(MODID), request.method))
@@ -659,6 +663,38 @@ def delete(request):
             config.db_close()
             return group_list(request, active_user=active_user, response_code=1, message='%s group flavors delete "%s" failed - %s.' % (lno(MODID), fields['group_name'], msg))
 
+        # Delete the group from the user
+        # rc, msg = manage_user_groups(config, None, active_user.username, active_user.user_groups.remove(fields['group_name']), option='delete')
+        # if rc != 0:
+        #     config.close()
+        #     return group_list(request, active_user=active_user, response_code=1, message=f"{lno(MODID)} Failed to remove group {fields['group_name']} from user {active_user.username}, {msg}")
+        # if group being deleted is active_user.active_group
+        # we should switch away from the group
+        if fields['group_name'] == active_user.active_group:
+            logger = logging.getLogger()
+            logger.setLevel(logging.INFO)
+            file_handler = logging.FileHandler('/opt/cloudscheduler/log.log')
+            file_handler.setLevel(logging.DEBUG)
+            logger.addHandler(file_handler)
+            logging.info(f"{fields['group_name']} being deleted is same as user's current active group:{active_user.active_group}") 
+            logging.info(f"fields: {fields}")
+            logging.info(f"active_user:{active_user}")
+            logging.info(f"active_group:{active_user.active_group}, \nuser_groups:{active_user.user_groups}, \navailable_groups:{active_user.available_groups}, \ndefault: {active_user.default_group}")
+            try:
+                # determine a suitable group to switch to
+                    # switch to default group if it is present and not being deleted
+                if active_user.default_group != None and active_user.default_group != active_user.active_group:
+                    logging.info(f"switching to default group: {active_user.default_group}")
+                    active_user.active_group = active_user.default_group
+                # switch to the first valid group in user_groups if there are any
+                elif len(active_user.user_groups) > 0:
+                    active_user.active_group = active_user.user_groups[0]
+                # there are no groups for this user, set the active group to the
+                # default constructor value
+                else:
+                    active_user.active_group = '-'
+            except Exception as err:
+                logging.info(f"error: {err}")
         # Delete the group.
         table = 'csv2_groups'
         rc, msg = config.db_delete(table, where=where_clause)


### PR DESCRIPTION
This change removes the previous fix that created a bug where sending web requests to switch in to an nonexistant or otherwise invalid group would result in the active group returned being the user's first valid group instead of receiving an error. The server will now check if the group a user is requesting to delete is the same as the current active group and then switch out of it to another valid group before doing the delete.