### PR TITLE
default.yaml.j2: quote all write_files "permissions" values.

### DIFF
--- a/metadata/default.yaml.j2
+++ b/metadata/default.yaml.j2
@@ -6,17 +6,17 @@ write_files:
 -   content: |                                                                                                                                                      
         {{cs_cloud_type}}                                                                                                                                           
     owner: root:root                                                                                                                                                
-    permissions: 0644
+    permissions: '0644'
     path: /var/lib/cloud_type
 -   content: |
         {{cs_condor_host}}
     owner: root:root
-    permissions: 0644
+    permissions: '0644'
     path: /etc/condor/central_manager
 -   content: |                                                                                                                                                      
         {{cs_cloud_name}}                                                                                                                                           
     owner: root:root                                                                                                                                                
-    permissions: 0644                                                                                                                                               
+    permissions: '0644'
     path: /var/lib/cloud_name                                                                                                                                       
 -   content: |                                                                                                                                                      
         # Local config for Cloud Scheduler


### PR DESCRIPTION
Cloud-init expects that all "permissions" values be strings.  Unquoted values are parsed as numbers, which are then rejected by Cloud-init because they are not strings.