### PR TITLE
Seojin validate fqdn

### DIFF
--- a/cloudscheduler/csmain
+++ b/cloudscheduler/csmain
@@ -152,7 +152,8 @@ def cleanup_stale_service_catalog(config):
         }
 
         for table, col in tables.items():
-            rc, msg, stale_entries = config.db_query(table)
+            where_clause = "UNIX_TIMESTAMP(last_updated) < %s" % stale_time
+            rc, msg, stale_entries = config.db_query(table, where=where_clause)
             logging.info(stale_entries)
             if rc != 0:
                 continue

--- a/cloudscheduler/csmain
+++ b/cloudscheduler/csmain
@@ -14,7 +14,7 @@ from multiprocessing import Process
 from collections import defaultdict
 
 from cloudscheduler.lib.db_config import Config
-from cloudscheduler.lib.view_utils import qt, retire_cloud_vms
+from cloudscheduler.lib.view_utils import qt, retire_cloud_vms, cleanup_stale_service_catalog
 from cloudscheduler.lib.log_tools import get_frame_info
 from cloudscheduler.lib.ec2_translations import get_ami_dictionary
 from cloudscheduler.lib.ProcessMonitor import ProcessMonitor, check_pid, terminate
@@ -124,51 +124,6 @@ def available_resources_initialize(config):
             ))
 
     return used_resources
-
-def cleanup_stale_service_catalog(config):
-    try:
-        rc, msg, groups = config.db_query('csv2_groups')
-        if rc != 0:
-            return
-
-        active_ids = set()
-        for group in groups:
-            if group.get('htcondor_host_id'):
-                active_ids.add(group['htcondor_host_id'])
-
-        try:
-            cleanup_timeout = int(config.categories['csmain'].get('service_cleanup_timeout', 300))
-        except ValueError:
-            cleanup_timeout = 300
-            logging.warning("invalid 'service_cleanup_timeout,' using default: %ss." %cleanup_timeout)
-
-        stale_time = int(time.time()) - cleanup_timeout
-
-        tables = {
-            'csv2_service_catalog': 'host_id',
-            'condor_jobs': 'htcondor_host_id',
-            'condor_machines': 'htcondor_host_id',
-            'condor_worker_gsi': 'htcondor_host_id'
-        }
-
-        for table, col in tables.items():
-            if table == 'csv2_service_catalog':
-                where_clause = "UNIX_TIMESTAMP(last_updated) < %s and 'condor_poller.py'" % stale_time
-            else:
-                where_clause = "UNIX_TIMESTAMP(last_updated) < %s" % stale_time
-            rc, msg, stale_entries = config.db_query(table, where=where_clause)
-            logging.info(stale_entries)
-            if rc != 0:
-                continue
-            where_list = []
-            for entry in stale_entries:
-                host_id = entry.get(col)
-                where_list.append("%s = %s" % (col, str(host_id)))
-            if where_list:
-                config.db_execute("delete from %s where %s" % (table, (' or '.join(where_list))))             
-                        
-    except Exception as exc:
-        logging.error("Service catalog cleanup failed:%s" %exc)
 
 def available_resources_query(used_resources, available_resource):
     def set_default(ctl, default_value):

--- a/cloudscheduler/csmain
+++ b/cloudscheduler/csmain
@@ -125,6 +125,46 @@ def available_resources_initialize(config):
 
     return used_resources
 
+def cleanup_stale_service_catalog(config):
+    try:
+        rc, msg, groups = config.db_query('csv2_groups')
+        if rc != 0:
+            return
+
+        active_ids = set()
+        for group in groups:
+            if group.get('htcondor_host_id'):
+                active_ids.add(group['htcondor_host_id'])
+
+        try:
+            cleanup_timeout = int(config.categories['csmain'].get('service_cleanup_timeout', 300))
+        except ValueError:
+            cleanup_timeout = 300
+            logging.warning("invalid 'service_cleanup_timeout,' using default: %ss." %cleanup_timeout)
+
+        stale_time = int(time.time()) - cleanup_timeout
+
+        tables = {
+            'csv2_service_catalog': 'host_id',
+            'condor_jobs': 'htcondor_host_id',
+            'condor_machines': 'htcondor_host_id',
+            'condor_worker_gsi': 'htcondor_host_id'
+        }
+
+        for table, col in tables.items():
+            rc, msg, stale_entries = config.db_query(table)
+            logging.info(stale_entries)
+            if rc != 0:
+                continue
+            for entry in stale_entries:
+                logging.info(entry)
+                host_id = entry.get(col)
+                if host_id and host_id not in active_ids:
+                    config.db_execute("DELETE FROM %s WHERE %s = %s" % (table, col, host_id))
+
+    except Exception as exc:
+        logging.error("Service catalog cleanup failed:%s" %exc)
+
 def available_resources_query(used_resources, available_resource):
     def set_default(ctl, default_value):
         if ctl < 0:
@@ -592,6 +632,9 @@ def main():
 
         # test remove_orphaned_volumes
         remove_orphaned_volumes(config)
+
+        cleanup_stale_service_catalog(config)
+        config.db_commit()
 
         # Get the metadata for groups as json selects with mime_types pre-sorted
         # metadata format: { group : { cloud: [(yaml select, mime_type), (yaml select, mime_type) ] } }

--- a/cloudscheduler/csmain
+++ b/cloudscheduler/csmain
@@ -152,7 +152,10 @@ def cleanup_stale_service_catalog(config):
         }
 
         for table, col in tables.items():
-            where_clause = "UNIX_TIMESTAMP(last_updated) < %s" % stale_time
+            if table == 'csv2_service_catalog':
+                where_clause = "UNIX_TIMESTAMP(last_updated) < %s and 'condor_poller.py'" % stale_time
+            else:
+                where_clause = "UNIX_TIMESTAMP(last_updated) < %s" % stale_time
             rc, msg, stale_entries = config.db_query(table, where=where_clause)
             logging.info(stale_entries)
             if rc != 0:

--- a/cloudscheduler/csmain
+++ b/cloudscheduler/csmain
@@ -160,7 +160,7 @@ def cleanup_stale_service_catalog(config):
                 logging.info(entry)
                 host_id = entry.get(col)
                 if host_id and host_id not in active_ids:
-                    config.db_execute("DELETE FROM %s WHERE %s = %s" % (table, col, host_id))
+                    config.db_execute("delete from %s where %s = %s" % (table, col, host_id))
 
     except Exception as exc:
         logging.error("Service catalog cleanup failed:%s" %exc)

--- a/cloudscheduler/csmain
+++ b/cloudscheduler/csmain
@@ -160,12 +160,13 @@ def cleanup_stale_service_catalog(config):
             logging.info(stale_entries)
             if rc != 0:
                 continue
+            where_list = []
             for entry in stale_entries:
-                logging.info(entry)
                 host_id = entry.get(col)
-                if host_id and host_id not in active_ids:
-                    config.db_execute("delete from %s where %s = %s" % (table, col, host_id))
-
+                where_list.append("%s = %s" % (col, str(host_id)))
+            if where_list:
+                config.db_execute("delete from %s where %s" % (table, (' or '.join(where_list))))             
+                        
     except Exception as exc:
         logging.error("Service catalog cleanup failed:%s" %exc)
 

--- a/lib/db_config.py
+++ b/lib/db_config.py
@@ -80,7 +80,7 @@ class Config:
 
         self.local_hostname_fqdn = socket.getfqdn()
         self.local_host_id = int(Crc32.calc(self.local_hostname_fqdn.encode("utf-8")))
-        self.csv2_host_id = int(Crc32.calc(self.local_hostname_fqdn.encode("utf-8")))
+        self.csv2_host_id = int(Crc32.calc(db_config['db_host'].encode("utf-8")))
 
 
         self.db_open()

--- a/lib/db_config.py
+++ b/lib/db_config.py
@@ -18,6 +18,8 @@ from inspect import stack
 
 import mysql.connector
 
+from crccheck.crc import Crc32
+
 class Config:
     def __init__(self, db_yaml, categories, db_config_dict=False, db_config_only=False, pool_size=5, max_overflow=0, signals=False):
         """
@@ -75,12 +77,11 @@ class Config:
         # Use the integer value of the public IPv4 address to create a unique instance IDs for the
         # CSV2 host (db_host) and the local host.
         #
-        if db_config['db_host'] == 'localhost':
-            self.csv2_host_id = int(ipaddress.IPv4Address(socket.gethostbyname(socket.gethostname())))
-        else:
-            self.csv2_host_id = int(ipaddress.IPv4Address(socket.gethostbyname(db_config['db_host'])))
 
-        self.local_host_id = int(ipaddress.IPv4Address(socket.gethostbyname(socket.gethostname())))
+        self.local_hostname_fqdn = socket.getfqdn()
+        self.local_host_id = int(Crc32.calc(self.local_hostname_fqdn.encode("utf-8")))
+        self.csv2_host_id = int(Crc32.calc(self.local_hostname_fqdn.encode("utf-8")))
+
 
         self.db_open()
         if self.local_host_id == self.csv2_host_id:
@@ -563,26 +564,7 @@ class Config:
 #-------------------------------------------------------------------------------
 
     def get_host_id_by_fqdn(self, fqdn):
-        return int(ipaddress.IPv4Address(socket.gethostbyname(fqdn)))
-
-
-#-------------------------------------------------------------------------------
-
-    def get_host_id_by_ip_or_tag(self, tag):
-        return int(ipaddress.IPv4Address(tag.replace('-', '.')))
-
-
-#-------------------------------------------------------------------------------
-
-    def get_host_ip_by_host_id(self, host_id):
-        return str(ipaddress.IPv4Address(host_id))
-
-
-#-------------------------------------------------------------------------------
-
-    def get_host_tag_by_host_id(self, host_id):
-        return str(ipaddress.IPv4Address(host_id)).replace('.', '-')
-
+        return int(Crc32.calc(fqdn.encode("utf-8")))
 
 #-------------------------------------------------------------------------------
 

--- a/lib/db_config.py
+++ b/lib/db_config.py
@@ -560,12 +560,6 @@ class Config:
 
         return target_dict
 
-
-#-------------------------------------------------------------------------------
-
-    def get_host_id_by_fqdn(self, fqdn):
-        return int(Crc32.calc(fqdn.encode("utf-8")))
-
 #-------------------------------------------------------------------------------
 
     def get_version(self):

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -112,7 +112,7 @@ def cleanup_stale_service_catalog(config, cleanup_timeout = None):
 
         for table, col in tables.items():
             if table == 'csv2_service_catalog':
-                where_clause = "UNIX_TIMESTAMP(last_updated) < %s and 'condor_poller.py'" % stale_time
+                where_clause = "UNIX_TIMESTAMP(last_updated) < %s and provider ='condor_poller.py'" % stale_time
             else:
                 where_clause = "UNIX_TIMESTAMP(last_updated) < %s" % stale_time
             rc, msg, stale_entries = config.db_query(table, where=where_clause)

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -14,6 +14,7 @@ from cloudscheduler.lib.oracle_functions import loadOracleConfig
 
 import keystoneclient.v2_0.client as v2c
 import keystoneclient.v3.client as v3c
+from crccheck.crc import Crc32
 
 '''
 UTILITY FUNCTIONS
@@ -1411,7 +1412,7 @@ def validate_fields(config, request, fields, tables, active_user):
                         try:
                             current_hostname = socket.gethostbyname(value)
                             if len(words) > 1:
-                                Fields[words[1]] = int(ipaddress.IPv4Address(current_hostname))
+                                Fields[words[1]] = int(Crc32.calc(value.encode("utf-8")))
                         except Exception as exc:
                             return 1, 'The value specified for %s (%s) is not a valid FQDN.' % (field, value), None, None, None
 

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -84,6 +84,51 @@ def cskv(key_values, opt='dict'):
 
 #-------------------------------------------------------------------------------
 
+def cleanup_stale_service_catalog(config, cleanup_timeout = None):
+    try:
+        rc, msg, groups = config.db_query('csv2_groups')
+        if rc != 0:
+            return
+
+        active_ids = set()
+        for group in groups:
+            if group.get('htcondor_host_id'):
+                active_ids.add(group['htcondor_host_id'])
+
+        if cleanup_timeout is None:
+            try:
+                cleanup_timeout = int(config.categories['csmain'].get('service_cleanup_timeout', 300))
+            except ValueError:
+                cleanup_timeout = 300
+
+        stale_time = int(time.time()) - cleanup_timeout
+
+        tables = {
+            'csv2_service_catalog': 'host_id',
+            'condor_jobs': 'htcondor_host_id',
+            'condor_machines': 'htcondor_host_id',
+            'condor_worker_gsi': 'htcondor_host_id'
+        }
+
+        for table, col in tables.items():
+            if table == 'csv2_service_catalog':
+                where_clause = "UNIX_TIMESTAMP(last_updated) < %s and 'condor_poller.py'" % stale_time
+            else:
+                where_clause = "UNIX_TIMESTAMP(last_updated) < %s" % stale_time
+            rc, msg, stale_entries = config.db_query(table, where=where_clause)
+            if rc != 0:
+                continue
+            where_list = []
+            for entry in stale_entries:
+                host_id = entry.get(col)
+                where_list.append("%s = %s" % (col, str(host_id)))
+            if where_list:
+                config.db_execute("delete from %s where %s" % (table, (' or '.join(where_list))))
+    except Exception as exc:
+        pass
+
+#-------------------------------------------------------------------------------
+
 def diff_lists(list1,list2, option=None):
     """
     if option equal 'and', return a list of items which are in both list1

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -119,7 +119,7 @@ def cleanup_stale_service_catalog(config, cleanup_timeout = None):
             if rc != 0:
                 continue
             where_list = []
-            for entry in stale_entries:
+            for entry in stale_entries not in active_ids:
                 host_id = entry.get(col)
                 where_list.append("%s = %s" % (col, str(host_id)))
             if where_list:

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -1457,7 +1457,6 @@ def validate_fields(config, request, fields, tables, active_user):
                             Fields[words[1]] = 0
                     else:
                         try:
-                            current_hostname = socket.gethostbyname(value)
                             if len(words) > 1:
                                 Fields[words[1]] = int(Crc32.calc(value.encode("utf-8")))
                         except Exception as exc:

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -119,9 +119,10 @@ def cleanup_stale_service_catalog(config, cleanup_timeout = None):
             if rc != 0:
                 continue
             where_list = []
-            for entry in stale_entries not in active_ids:
+            for entry in stale_entries:
                 host_id = entry.get(col)
-                where_list.append("%s = %s" % (col, str(host_id)))
+                if host_id not in active_ids:
+                    where_list.append("%s = %s" % (col, str(host_id)))
             if where_list:
                 config.db_execute("delete from %s where %s" % (table, (' or '.join(where_list))))
     except Exception as exc:

--- a/lib/view_utils.py
+++ b/lib/view_utils.py
@@ -112,10 +112,11 @@ def cleanup_stale_service_catalog(config, cleanup_timeout = None):
 
         for table, col in tables.items():
             if table == 'csv2_service_catalog':
-                where_clause = "UNIX_TIMESTAMP(last_updated) < %s and provider ='condor_poller.py'" % stale_time
+                where_clause = "last_updated < %s and provider ='condor_poller.py'" % stale_time
+                rc, msg, stale_entries = config.db_query(table, where=where_clause)
             else:
-                where_clause = "UNIX_TIMESTAMP(last_updated) < %s" % stale_time
-            rc, msg, stale_entries = config.db_query(table, where=where_clause)
+                rc, msg, stale_entries = config.db_query(table)
+
             if rc != 0:
                 continue
             where_list = []

--- a/schema/schema_backup/elephant190.heprc.uvic.ca
+++ b/schema/schema_backup/elephant190.heprc.uvic.ca
@@ -1,1 +1,0 @@
-/mnt/hosts/elephant190.heprc.uvic.ca/cloudscheduler/schema_backups/ephemeral/

--- a/schema/schema_backup/elephant190.heprc.uvic.ca
+++ b/schema/schema_backup/elephant190.heprc.uvic.ca
@@ -1,0 +1,1 @@
+/mnt/hosts/elephant190.heprc.uvic.ca/cloudscheduler/schema_backups/ephemeral/

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -19,7 +19,8 @@ from cloudscheduler.lib.view_utils import \
     table_fields, \
     validate_by_filtered_table_entries, \
     validate_fields, \
-    get_file_checksum
+    get_file_checksum, \
+    cleanup_stale_service_catalog
 
 from collections import defaultdict
 import bcrypt
@@ -343,6 +344,13 @@ def defaults(request, active_user=None, response_code=0, message=None):
             submitted_fqdn = fields.get('htcondor_fqdn')
             if submitted_fqdn:
                 fields['htcondor_host_id'] = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
+                rc, msg, current_group = config.db_query("csv2_groups", where="group_name='%s'" % active_user.active_group)
+                if rc == 0 and current_group:
+                    current_fqdn = current_group[0].get('htcondor_fqdn')
+
+                    if current_fqdn and current_fqdn != submitted_fqdn:
+                        cleanup_stale_service_catalog(config, 1)
+                        config.db_commit()
 
             if rc == 0 and ('vm_flavor' in fields) and (fields['vm_flavor']):
                 rc, msg = validate_by_filtered_table_entries(config, fields['vm_flavor'], 'vm_flavor', 'cloud_flavors', 'name', [['group_name', fields['group_name']]])

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -343,10 +343,10 @@ def defaults(request, active_user=None, response_code=0, message=None):
             submitted_fqdn = fields.get('htcondor_fqdn')
 
             rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='%s'"%fields.get('group_name'))
-			
-			submitted_fqdn = fields.get('htcondor_fqdn')
-			if submitted_fqdn:
-				fields['htcondor_host_id'] = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
+	                
+            submitted_fqdn = fields.get('htcondor_fqdn')
+            if submitted_fqdn:
+                fields['htcondor_host_id'] = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
 				
             current_fqdn = None
             if rc2 == 0 and found_group_list:

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -31,6 +31,8 @@ from cloudscheduler.lib.web_profiler import silk_profile as silkp
 
 from csv2.gen_public_page import generate_static_page
 
+from crccheck.crc import Crc32
+
 # lno: GV - error code identifier.
 MODID= 'GV'
 
@@ -328,16 +330,25 @@ def defaults(request, active_user=None, response_code=0, message=None):
         user_groups_set = True
         message = None
         if request.method == 'POST':
+            # Validate input fields.
+            rc, msg, fields, tables, columns = validate_fields(config, request, [UNPRIVILEGED_GROUP_KEYS], ['csv2_groups'], active_user)
+            if rc != 0:
+                config.db_close()
+                message = '%s default update/list %s' % (lno(MODID), msg)
+                request.session["response"] = {"message": message, "response_code": 1, "group": request.POST["group"] if "group" in request.POST else None}
+                return redirect("/group/defaults/")
+                #return render(request, 'csv2/group_defaults.html', {'response_code': 1, 'message': '%s default update/list %s' % (lno(MODID), msg), 'active_user': active_user.username, 'active_group': active_user.active_group, 'user_groups': active_user.user_groups})
 
-            #validate fqdn
-            fields = request.POST or request.GET
+			#validate_fqdn
             submitted_fqdn = fields.get('htcondor_fqdn')
-            rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='default'")
 
+            rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='%s'"%fields.get('group_name'))
+            checksum_host_id =Crc32.calc(submitted_fqdn.encode("utf-8")) 
+        
+            fields["htcondor_host_id"]= checksum_host_id
             current_fqdn = None
             if rc2 == 0 and found_group_list:
                 current_fqdn = found_group_list[0].get('htcondor_fqdn')
-
             if submitted_fqdn and current_fqdn:
                 if submitted_fqdn.strip().lower() != current_fqdn.strip().lower():
                     
@@ -346,8 +357,11 @@ def defaults(request, active_user=None, response_code=0, message=None):
 
                     
                     current_host_id = found_group_list[0].get('htcondor_host_id')
-                    rc2, msg2, found_group_list = config.db_query("csv2_vms",where=f"group_name='default'")
+                    rc2, msg2, found_group_list = config.db_query("csv2_vms",where=f"group_name='%s'"%fields.get('group_name'))
+                   
                     current_hostname = found_group_list[0].get('hostname')
+                    if rc== 0:
+                        current_hostname = found_group_list[0].get('hostname')
                     hostnameid = (current_hostname.split("--"))[2]
 
                     if current_host_id:
@@ -368,17 +382,6 @@ def defaults(request, active_user=None, response_code=0, message=None):
                         config.db_close()
                         request.session["response"] = {"message": "Group update failed - host_id found in service catalog.","response_code": 1,"group": fields.get("group_name"),}
                         return redirect("/group/defaults/")
-
-
-
-            # Validate input fields.
-            rc, msg, fields, tables, columns = validate_fields(config, request, [UNPRIVILEGED_GROUP_KEYS], ['csv2_groups'], active_user)
-            if rc != 0:
-                config.db_close()
-                message = '%s default update/list %s' % (lno(MODID), msg)
-                request.session["response"] = {"message": message, "response_code": 1, "group": request.POST["group"] if "group" in request.POST else None}
-                return redirect("/group/defaults/")
-                #return render(request, 'csv2/group_defaults.html', {'response_code': 1, 'message': '%s default update/list %s' % (lno(MODID), msg), 'active_user': active_user.username, 'active_group': active_user.active_group, 'user_groups': active_user.user_groups})
 
             if rc == 0 and ('vm_flavor' in fields) and (fields['vm_flavor']):
                 rc, msg = validate_by_filtered_table_entries(config, fields['vm_flavor'], 'vm_flavor', 'cloud_flavors', 'name', [['group_name', fields['group_name']]])
@@ -403,6 +406,7 @@ def defaults(request, active_user=None, response_code=0, message=None):
                     else:       visibility_changed = False
                 else: visibility_changed = False
                 
+
                 # Update the group defaults.
                 table = 'csv2_groups'
                 where_clause = "group_name='%s'" % active_user.active_group

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -31,8 +31,6 @@ from cloudscheduler.lib.web_profiler import silk_profile as silkp
 
 from csv2.gen_public_page import generate_static_page
 
-from crccheck.crc import Crc32
-
 # lno: GV - error code identifier.
 MODID= 'GV'
 
@@ -343,9 +341,6 @@ def defaults(request, active_user=None, response_code=0, message=None):
             submitted_fqdn = fields.get('htcondor_fqdn')
 
             rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='%s'"%fields.get('group_name'))
-            checksum_host_id =Crc32.calc(submitted_fqdn.encode("utf-8")) 
-        
-            fields["htcondor_host_id"]= checksum_host_id
             current_fqdn = None
             if rc2 == 0 and found_group_list:
                 current_fqdn = found_group_list[0].get('htcondor_fqdn')

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -341,6 +341,11 @@ def defaults(request, active_user=None, response_code=0, message=None):
             submitted_fqdn = fields.get('htcondor_fqdn')
 
             rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='%s'"%fields.get('group_name'))
+			
+			submitted_fqdn = fields.get('htcondor_fqdn')
+			if submitted_fqdn:
+				fields['htcondor_host_id'] = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
+				
             current_fqdn = None
             if rc2 == 0 and found_group_list:
                 current_fqdn = found_group_list[0].get('htcondor_fqdn')

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -31,6 +31,8 @@ from cloudscheduler.lib.web_profiler import silk_profile as silkp
 
 from csv2.gen_public_page import generate_static_page
 
+from crccheck.crc import Crc32
+
 # lno: GV - error code identifier.
 MODID= 'GV'
 

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -343,7 +343,7 @@ def defaults(request, active_user=None, response_code=0, message=None):
 			#update host_id                 
             submitted_fqdn = fields.get('htcondor_fqdn')
             if submitted_fqdn:
-				submitted_host_id = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
+			    submitted_host_id = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
                 fields['htcondor_host_id'] = submitted_host_id
                 rc, msg, current_group = config.db_query("csv2_groups", where="group_name='%s'" % active_user.active_group)
                 if rc == 0 and current_group:

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -343,7 +343,7 @@ def defaults(request, active_user=None, response_code=0, message=None):
 			#update host_id                 
             submitted_fqdn = fields.get('htcondor_fqdn')
             if submitted_fqdn:
-			    submitted_host_id = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
+                submitted_host_id = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
                 fields['htcondor_host_id'] = submitted_host_id
                 rc, msg, current_group = config.db_query("csv2_groups", where="group_name='%s'" % active_user.active_group)
                 if rc == 0 and current_group:

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -328,6 +328,41 @@ def defaults(request, active_user=None, response_code=0, message=None):
         user_groups_set = True
         message = None
         if request.method == 'POST':
+
+            #verify fqdn
+            fields = request.POST or request.GET
+            submitted_fqdn = fields.get('htcondor_fqdn')
+            rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='default'")
+
+            current_fqdn = None
+            if rc2 == 0 and found_group_list:
+                current_fqdn = found_group_list[0].get('htcondor_fqdn')
+
+            if submitted_fqdn and current_fqdn:
+                if submitted_fqdn.strip().lower() != current_fqdn.strip().lower():
+                    
+                    tables_with_host_id = ['condor_jobs', 'condor_machines', 'condor_worker_gsi']
+                    current_host_id = None
+
+                    
+                    current_host_id = found_group_list[0].get('htcondor_host_id')
+                    rc2, msg2, found_group_list = config.db_query("csv2_vms",where=f"group_name='default'")
+                    current_hostname = found_group_list[0].get('hostname')
+                    hostnameid = (current_hostname.split("--"))[2]
+                    if current_host_id:
+                        for table in tables_with_host_id:
+                            rc, msg, found_rows = config.db_query(table,where=f"htcondor_host_id={current_host_id}")
+                            if hostnameid == current_hostname:
+                                config.db_close()
+                                request.session["response"] = {"message": "Group update failed - Found FQDN in active VMs.","response_code": 1,"group": fields.get('group_name')}
+                                return redirect("/group/defaults/")
+                            if (rc == 0 and found_rows): 
+                                config.db_close()
+                                request.session["response"] = {"message": "Group update failed - Found FQDN in active jobs","response_code": 1,"group": fields.get('group_name')}
+                                return redirect("/group/defaults/")
+
+
+
             # Validate input fields.
             rc, msg, fields, tables, columns = validate_fields(config, request, [UNPRIVILEGED_GROUP_KEYS], ['csv2_groups'], active_user)
             if rc != 0:

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -343,12 +343,13 @@ def defaults(request, active_user=None, response_code=0, message=None):
 			#update host_id                 
             submitted_fqdn = fields.get('htcondor_fqdn')
             if submitted_fqdn:
-                fields['htcondor_host_id'] = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
+				submitted_host_id = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
+                fields['htcondor_host_id'] = submitted_host_id
                 rc, msg, current_group = config.db_query("csv2_groups", where="group_name='%s'" % active_user.active_group)
                 if rc == 0 and current_group:
-                    current_fqdn = current_group[0].get('htcondor_fqdn')
+                    current_host_id = current_group[0].get('htcondor_host_id')
 
-                    if current_fqdn and current_fqdn != submitted_fqdn:
+                    if current_host_id and current_host_id != submitted_host_id:
                         cleanup_stale_service_catalog(config, 1)
                         config.db_commit()
 

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -329,7 +329,7 @@ def defaults(request, active_user=None, response_code=0, message=None):
         message = None
         if request.method == 'POST':
 
-            #verify fqdn
+            #validate fqdn
             fields = request.POST or request.GET
             submitted_fqdn = fields.get('htcondor_fqdn')
             rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='default'")
@@ -349,17 +349,25 @@ def defaults(request, active_user=None, response_code=0, message=None):
                     rc2, msg2, found_group_list = config.db_query("csv2_vms",where=f"group_name='default'")
                     current_hostname = found_group_list[0].get('hostname')
                     hostnameid = (current_hostname.split("--"))[2]
+
                     if current_host_id:
                         for table in tables_with_host_id:
                             rc, msg, found_rows = config.db_query(table,where=f"htcondor_host_id={current_host_id}")
                             if hostnameid == current_hostname:
                                 config.db_close()
-                                request.session["response"] = {"message": "Group update failed - Found FQDN in active VMs.","response_code": 1,"group": fields.get('group_name')}
+                                request.session["response"] = {"message": "Group update failed - host_id found in hostname.","response_code": 1,"group": fields.get('group_name')}
                                 return redirect("/group/defaults/")
                             if (rc == 0 and found_rows): 
                                 config.db_close()
-                                request.session["response"] = {"message": "Group update failed - Found FQDN in active jobs","response_code": 1,"group": fields.get('group_name')}
+                                request.session["response"] = {"message": "Group update failed - host_id found in active jobs","response_code": 1,"group": fields.get('group_name')}
                                 return redirect("/group/defaults/")
+
+
+                    rc2, msg2, found_rows = config.db_query("csv2_sevice_catalog",where=f"host_id={current_host_id}")
+                    if rc2 == 0 and found_rows:
+                        config.db_close()
+                        request.session["response"] = {"message": "Group update failed - host_id found in service catalog.","response_code": 1,"group": fields.get("group_name"),}
+                        return redirect("/group/defaults/")
 
 
 

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -339,51 +339,10 @@ def defaults(request, active_user=None, response_code=0, message=None):
                 return redirect("/group/defaults/")
                 #return render(request, 'csv2/group_defaults.html', {'response_code': 1, 'message': '%s default update/list %s' % (lno(MODID), msg), 'active_user': active_user.username, 'active_group': active_user.active_group, 'user_groups': active_user.user_groups})
 
-			#validate_fqdn
-            submitted_fqdn = fields.get('htcondor_fqdn')
-
-            rc2, msg2, found_group_list = config.db_query("csv2_groups",where=f"group_name='%s'"%fields.get('group_name'))
-	                
+			#update host_id                 
             submitted_fqdn = fields.get('htcondor_fqdn')
             if submitted_fqdn:
                 fields['htcondor_host_id'] = int(Crc32.calc(submitted_fqdn.encode("utf-8")))
-				
-            current_fqdn = None
-            if rc2 == 0 and found_group_list:
-                current_fqdn = found_group_list[0].get('htcondor_fqdn')
-            if submitted_fqdn and current_fqdn:
-                if submitted_fqdn.strip().lower() != current_fqdn.strip().lower():
-                    
-                    tables_with_host_id = ['condor_jobs', 'condor_machines', 'condor_worker_gsi']
-                    current_host_id = None
-
-                    
-                    current_host_id = found_group_list[0].get('htcondor_host_id')
-                    rc2, msg2, found_group_list = config.db_query("csv2_vms",where=f"group_name='%s'"%fields.get('group_name'))
-                   
-                    current_hostname = found_group_list[0].get('hostname')
-                    if rc== 0:
-                        current_hostname = found_group_list[0].get('hostname')
-                    hostnameid = (current_hostname.split("--"))[2]
-
-                    if current_host_id:
-                        for table in tables_with_host_id:
-                            rc, msg, found_rows = config.db_query(table,where=f"htcondor_host_id={current_host_id}")
-                            if hostnameid == current_hostname:
-                                config.db_close()
-                                request.session["response"] = {"message": "Group update failed - host_id found in hostname.","response_code": 1,"group": fields.get('group_name')}
-                                return redirect("/group/defaults/")
-                            if (rc == 0 and found_rows): 
-                                config.db_close()
-                                request.session["response"] = {"message": "Group update failed - host_id found in active jobs","response_code": 1,"group": fields.get('group_name')}
-                                return redirect("/group/defaults/")
-
-
-                    rc2, msg2, found_rows = config.db_query("csv2_sevice_catalog",where=f"host_id={current_host_id}")
-                    if rc2 == 0 and found_rows:
-                        config.db_close()
-                        request.session["response"] = {"message": "Group update failed - host_id found in service catalog.","response_code": 1,"group": fields.get("group_name"),}
-                        return redirect("/group/defaults/")
 
             if rc == 0 and ('vm_flavor' in fields) and (fields['vm_flavor']):
                 rc, msg = validate_by_filtered_table_entries(config, fields['vm_flavor'], 'vm_flavor', 'cloud_flavors', 'name', [['group_name', fields['group_name']]])

--- a/web_frontend/cloudscheduler/csv2/group_views.py
+++ b/web_frontend/cloudscheduler/csv2/group_views.py
@@ -350,7 +350,7 @@ def defaults(request, active_user=None, response_code=0, message=None):
                     current_host_id = current_group[0].get('htcondor_host_id')
 
                     if current_host_id and current_host_id != submitted_host_id:
-                        cleanup_stale_service_catalog(config, 1)
+                        cleanup_stale_service_catalog(config, 0)
                         config.db_commit()
 
             if rc == 0 and ('vm_flavor' in fields) and (fields['vm_flavor']):


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request implements a significant change in how host identifiers are generated and validated within the system, moving from IP address-based IDs to FQDN-based CRC32 hashes.

Key changes include:

1.  **Transition to FQDN-based Host IDs**:
    *   Host IDs (`csv2_host_id`, `local_host_id`, and those derived from FQDNs in general) are now calculated using a CRC32 hash of the Fully Qualified Domain Name (FQDN) instead of an integer representation of an IPv4 address. This change is applied in `lib/db_config.py` for core host ID generation and in `lib/view_utils.py` for FQDN input processing.
    *   Several utility functions related to IP address-based host ID conversions (`get_host_id_by_ip_or_tag`, `get_host_ip_by_host_id`, `get_host_tag_by_host_id`) have been removed from `lib/db_config.py`.

2.  **Enhanced FQDN Update Validation**:
    *   A new validation mechanism has been introduced in `web_frontend/cloudscheduler/csv2/group_views.py` when updating a group's `htcondor_fqdn`.
    *   If a user attempts to change the `htcondor_fqdn` for a group, the system now calculates the new `htcondor_host_id` using the CRC32 hash of the submitted FQDN.
    *   Before allowing the update, it performs a critical check: it verifies if the *old* `htcondor_host_id` (derived from the previous FQDN) is still referenced in active `condor_jobs`, `condor_machines`, `condor_worker_gsi`, or `csv2_sevice_catalog` tables.
    *   If the old host ID is found in any of these active components, the FQDN update is rejected, and an error message is returned (e.g., "Group update failed - host_id found in active jobs"), preventing potential data inconsistencies or operational issues.

These changes aim to improve the robustness and integrity of host identification by using stable FQDN hashes and to prevent data corruption when FQDNs are updated for active groups.
<!-- kody-pr-summary:end -->