### PR TITLE
Seojin issue 439

### DIFF
--- a/utilities/restore_group.sh
+++ b/utilities/restore_group.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mysql csv2 -e "
+insert into csv2_groups (group_name) values ('default');
+insert into csv2_user_groups (username, group_name)
+select username, 'default'
+from csv2_user
+where is_superuser = 1
+on duplicate key update group_name='default';
+"

--- a/utilities/restore_group.sh
+++ b/utilities/restore_group.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+###
+### This utility must be run as root. It performs the following:
+###
+### 1.  Adds a 'default' group to csv2_groups table
+### 2.  Inserts 'default' group to csv2_user_groups along with any superusers from the csv2_user table
 
 mysql csv2 -e "
 insert into csv2_groups (group_name) values ('default');

--- a/utilities/restore_group.sh
+++ b/utilities/restore_group.sh
@@ -6,7 +6,7 @@
 ### 2.  Inserts 'default' group to csv2_user_groups along with any superusers from the csv2_user table
 
 mysql csv2 -e "
-insert into csv2_groups (group_name) values ('default');
+insert ignore into csv2_groups (group_name) values ('default');
 insert into csv2_user_groups (username, group_name)
 select username, 'default'
 from csv2_user

--- a/web_frontend/cloudscheduler/cloudscheduler_web/urls.py
+++ b/web_frontend/cloudscheduler/cloudscheduler_web/urls.py
@@ -18,6 +18,8 @@ from django.conf import settings
 from django.conf.urls import include
 from django.urls import re_path
 from django.contrib import admin
+from django.conf.urls import handler403
+from django.views.generic import TemplateView
 
 urlpatterns = [
     re_path(r'^admin/', admin.site.urls),
@@ -29,3 +31,4 @@ urlpatterns = [
 if settings.CSV2_CONFIG.categories["web_frontend"]["enable_profiling"]:
     urlpatterns += [re_path(r'^silk/', include('silk.urls', namespace='silk'))]
 
+handler403 = TemplateView.as_view(template_name='csv2/403.html')

--- a/web_frontend/cloudscheduler/cloudscheduler_web/urls.py
+++ b/web_frontend/cloudscheduler/cloudscheduler_web/urls.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.conf.urls import include
 from django.urls import re_path
 from django.contrib import admin
-from django.conf.urls import handler403
 from django.views.generic import TemplateView
 
 urlpatterns = [

--- a/web_frontend/cloudscheduler/csv2/templates/csv2/403.html
+++ b/web_frontend/cloudscheduler/csv2/templates/csv2/403.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <h1>Error SV-00055</h1>
+    <p>Sorry, you are not a member of any group</p>
+    <p>Please Contact your Administrator</p>
+  </body>
+</html>


### PR DESCRIPTION
Custom error page and utility function to add temp group to fix broken state.

---

<!-- kody-pr-summary:start -->
This pull request introduces a custom error page for HTTP 403 Forbidden responses in the web frontend and provides a utility script for group management.

Key changes include:
*   **Custom 403 Error Page:** A new HTML template (`csv2/403.html`) has been added to display a specific message ("Error SV-00055: Sorry, you are not a member of any group") when a user encounters a 403 Forbidden error. The web application's URL configuration has been updated to use this custom template for 403 errors.
*   **Group Restoration Utility:** A new shell script (`utilities/restore_group.sh`) has been added. This utility, designed to be run as root, ensures that a 'default' group exists in the `csv2_groups` table and assigns all existing superusers from the `csv2_user` table to this 'default' group within `csv2_user_groups`.
<!-- kody-pr-summary:end -->